### PR TITLE
Split ASCII art justification code into its own class.

### DIFF
--- a/src/MenuItem/AsciiArtItem.php
+++ b/src/MenuItem/AsciiArtItem.php
@@ -58,31 +58,13 @@ class AsciiArtItem implements MenuItemInterface
      */
     public function getRows(MenuStyle $style, $selected = false)
     {
-        return array_map(function ($row) use ($style) {
-            $length = mb_strlen($row);
+        $justificationHelper = new Helper\AsciiArtItemJustificationHelper(
+            $this->position,
+            $style->getContentWidth(),
+            $this->artLength);
 
-            $padding = $style->getContentWidth() - $length;
-
-            switch ($this->position) {
-                case self::POSITION_LEFT:
-                    return $row;
-                    break;
-                case self::POSITION_RIGHT:
-                    $row = rtrim($row);
-                    $padding = $padding - ($this->artLength - mb_strlen($row));
-                    $row = sprintf('%s%s', str_repeat(' ', $padding), $row);
-                    break;
-                case self::POSITION_CENTER:
-                default:
-                    $row = rtrim($row);
-                    $padding = $padding - ($this->artLength - mb_strlen($row));
-                    $left = ceil($padding/2);
-                    $right = $padding - $left;
-                    $row = sprintf('%s%s%s', str_repeat(' ', $left), $row, str_repeat(' ', $right));
-                    break;
-            }
-
-            return $row;
+        return array_map(function ($row) use ($justificationHelper) {
+            return $justificationHelper->justifyRow($row);
         }, explode("\n", $this->text));
     }
 

--- a/src/MenuItem/Helper/AsciiArtItemJustificationHelper.php
+++ b/src/MenuItem/Helper/AsciiArtItemJustificationHelper.php
@@ -1,0 +1,76 @@
+<?php
+namespace PhpSchool\CliMenu\MenuItem\Helper;
+
+use PhpSchool\CliMenu\MenuItem\AsciiArtItem;
+
+class AsciiArtItemJustificationHelper
+{
+    private $contentWidth;
+    private $artLength;
+    private $position;
+
+    public function  __construct($position, $contentWidth, $artLength)
+    {
+        $this->contentWidth = $contentWidth;
+        $this->artLength = $artLength;
+        $this->position = $position;
+    }
+
+    public function justifyRow($row)
+    {
+        switch ($this->position) {
+            case AsciiArtItem::POSITION_LEFT:
+                return $this->leftJustifyRow($row);
+            case AsciiArtItem::POSITION_RIGHT:
+                return $this->rightJustifyRow($row);
+            case AsciiArtItem::POSITION_CENTER:
+            default:
+                return $this->centerJustifyRow($row);
+        }
+    }
+
+    /**
+     * @param $row
+     * @return string
+     */
+    private function leftJustifyRow($row)
+    {
+        return $row;
+    }
+
+    /**
+     * @param $row
+     * @return string
+     */
+    private function rightJustifyRow($row)
+    {
+        $padding = $this->_getPadding($row);
+        $row = rtrim($row);
+        $padding = $padding - ($this->artLength - mb_strlen($row));
+        return sprintf('%s%s', str_repeat(' ', $padding), $row);
+    }
+
+    /**
+     * @param $row
+     * @return string
+     */
+    private function centerJustifyRow($row)
+    {
+        $padding = $this->_getPadding($row);
+        $row = rtrim($row);
+        $padding = $padding - ($this->artLength - mb_strlen($row));
+        $left = ceil($padding / 2);
+        $right = $padding - $left;
+        return sprintf('%s%s%s', str_repeat(' ', $left), $row, str_repeat(' ', $right));
+    }
+
+    /**
+     * @param $row
+     * @return int
+     */
+    private function _getPadding($row)
+    {
+        $length = mb_strlen($row);
+        return $this->contentWidth - $length;
+    }
+}


### PR DESCRIPTION
I think this is a little bit of an improvement, but possibly not as much as I originally hoped it would be... But I enjoyed writing it so it's not necessarily all wasted effort.

It certainly separates out concerns (AsciiArtItem now no longer concerns itself with how to justify its contents) which I think is a bit easier to understand now. Whether its worth the addition of the extra class is a decision I'll leave up to you. :-)