### PR TITLE
Tests for style inheritance

### DIFF
--- a/src/CliMenuBuilder.php
+++ b/src/CliMenuBuilder.php
@@ -468,7 +468,7 @@ class CliMenuBuilder
 
     /**
      * @param string $id
-     * @return CliMenuBuilder
+     * @return CliMenu
      * @throws RuntimeException
      */
     public function getSubMenu($id)

--- a/test/CliMenuBuilderTest.php
+++ b/test/CliMenuBuilderTest.php
@@ -278,6 +278,32 @@ class CliMenuBuilderTest extends PHPUnit_Framework_TestCase
         $this->assertSame($builder, $subMenuBuilder->end());
     }
 
+    public function testSubMenuInheritsParentsStyle()
+    {
+        $builder = new CliMenuBuilder;
+        $menu = $builder->setBackgroundColour('green')
+            ->addSubMenu('sub-menu')
+                ->addItem('Some Item', function () {})
+                ->end()
+            ->build();
+
+        $this->assertSame('green', $builder->getSubMenu('sub-menu')->getStyle()->getBg());
+    }
+
+    public function testSubMenuDoesNotInheritsParentsStyleWhenSubMenuStyleHasAlterations()
+    {
+        $builder = new CliMenuBuilder;
+        $menu = $builder->setBackgroundColour('green')
+            ->addSubMenu('sub-menu')
+                ->addItem('Some Item', function () {})
+                ->setBackgroundColour('red')
+                ->end()
+            ->build();
+
+        $this->assertSame('red', $builder->getSubMenu('sub-menu')->getStyle()->getBg());
+        $this->assertSame('green', $menu->getStyle()->getBg());
+    }
+
     public function testGetSubMenuThrowsExceptionIfNotBuiltYet()
     {
         $builder = (new CliMenuBuilder)

--- a/test/CliMenuBuilderTest.php
+++ b/test/CliMenuBuilderTest.php
@@ -283,7 +283,8 @@ class CliMenuBuilderTest extends PHPUnit_Framework_TestCase
         $builder = new CliMenuBuilder;
         $menu = $builder->setBackgroundColour('green')
             ->addSubMenu('sub-menu')
-                ->addItem('Some Item', function () {})
+                ->addItem('Some Item', function () {
+                })
                 ->end()
             ->build();
 
@@ -295,7 +296,8 @@ class CliMenuBuilderTest extends PHPUnit_Framework_TestCase
         $builder = new CliMenuBuilder;
         $menu = $builder->setBackgroundColour('green')
             ->addSubMenu('sub-menu')
-                ->addItem('Some Item', function () {})
+                ->addItem('Some Item', function () {
+                })
                 ->setBackgroundColour('red')
                 ->end()
             ->build();


### PR DESCRIPTION
Adding some tests for style inheritance because my next PR is going to remove the majority of the constructors args to `MenuStyle`, they should be modified only by the setters.