### PR TITLE
rebuild menu->item when someone has delete [key up & down fix]

### DIFF
--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -384,6 +384,7 @@ class CliMenu
         }
 
         unset($this->items[$key]);
+	    $this->items =array_values($this->items);
     }
 
     /**


### PR DESCRIPTION
$a=['a','b','c'];
unset($a[1]);
0=>'a',
2=>'c'
var_dump(array_values($a));
0=>'a',
1=>'c'