### PR TITLE
Use new static for submenu

### DIFF
--- a/src/CliMenuBuilder.php
+++ b/src/CliMenuBuilder.php
@@ -198,7 +198,7 @@ class CliMenuBuilder
         Assertion::string($id);
 
         $this->menuItems[]   = $id;
-        $this->subMenus[$id] = new self($this);
+        $this->subMenus[$id] = new static($this);
 
         return $this->subMenus[$id];
     }


### PR DESCRIPTION
On add submenu use "new static" not "new self"

This way a subclass of CliMenuBuilder will add sub menus of the same subclass type and not the parent class type.

This makes it easier to meaningfully extend.