### PR TITLE
Drop PHP 7.0 and 5.x support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,8 @@ before_script:
 
 script:
   - ./vendor/bin/phpunit --coverage-clover ./build/logs/clover.xml
-  - ./vendor/bin/phpcs --standard=PSR2 ./src/
-  - ./vendor/bin/phpcs --standard=PSR2 ./test/
+  - composer cs
+  - composer static
 
 after_script:
   - bash <(curl -s https://codecov.io/bash)

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,8 @@
 language: php
 
 php:
-  - 5.6
-  - 7.0
   - 7.1
   - 7.2
-  - hhvm
 
 install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "squizlabs/php_codesniffer": "~2.0"
     },
     "require": {
-        "php" : ">=5.6",
+        "php" : ">=7.1",
         "beberlei/assert": "^2.4",
         "ext-posix": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -14,8 +14,8 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "~5.0",
-        "squizlabs/php_codesniffer": "~2.0"
+        "phpunit/phpunit": "^7.1",
+        "squizlabs/php_codesniffer": "^3.2"
     },
     "require": {
         "php" : ">=7.1",

--- a/composer.json
+++ b/composer.json
@@ -35,6 +35,9 @@
         "cs" : [
             "phpcs src --standard=PSR2",
             "phpcs test --standard=PSR2"
+        ],
+        "static" : [
+            "phpstan analyse src --level=7"
         ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,8 @@
     ],
     "require-dev": {
         "phpunit/phpunit": "^7.1",
-        "squizlabs/php_codesniffer": "^3.2"
+        "squizlabs/php_codesniffer": "^3.2",
+        "phpstan/phpstan": "^0.9.2"
     },
     "require": {
         "php" : ">=7.1",

--- a/src/Action/ExitAction.php
+++ b/src/Action/ExitAction.php
@@ -9,10 +9,7 @@ use PhpSchool\CliMenu\CliMenu;
  */
 class ExitAction
 {
-    /**
-     * @param CliMenu $menu
-     */
-    public function __invoke(CliMenu $menu)
+    public function __invoke(CliMenu $menu) : void
     {
         $menu->close();
     }

--- a/src/Action/ExitAction.php
+++ b/src/Action/ExitAction.php
@@ -5,8 +5,6 @@ namespace PhpSchool\CliMenu\Action;
 use PhpSchool\CliMenu\CliMenu;
 
 /**
- * Class ExitAction
- * @package PhpSchool\CliMenu\Action
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
 class ExitAction

--- a/src/Action/GoBackAction.php
+++ b/src/Action/GoBackAction.php
@@ -9,10 +9,7 @@ use PhpSchool\CliMenu\CliMenu;
  */
 class GoBackAction
 {
-    /**
-     * @param CliMenu $menu
-     */
-    public function __invoke(CliMenu $menu)
+    public function __invoke(CliMenu $menu) : void
     {
         if ($parent = $menu->getParent()) {
             $menu->close();

--- a/src/Action/GoBackAction.php
+++ b/src/Action/GoBackAction.php
@@ -5,8 +5,6 @@ namespace PhpSchool\CliMenu\Action;
 use PhpSchool\CliMenu\CliMenu;
 
 /**
- * Class GoBackAction
- * @package PhpSchool\CliMenu\Action
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
 class GoBackAction

--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -15,9 +15,6 @@ use PhpSchool\CliMenu\Terminal\TerminalInterface;
 use PhpSchool\CliMenu\Util\StringUtil as s;
 
 /**
- * Class CliMenu
- *
- * @package PhpSchool\CliMenu
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
 class CliMenu

--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -30,7 +30,7 @@ class CliMenu
     protected $style;
 
     /**
-     * @var string
+     * @var ?string
      */
     protected $title;
 
@@ -55,12 +55,12 @@ class CliMenu
     protected $parent;
 
     /**
-     * @var Frame|null
+     * @var Frame
      */
     private $currentFrame;
 
     public function __construct(
-        string $title,
+        ?string $title,
         array $items,
         TerminalInterface $terminal = null,
         MenuStyle $style = null
@@ -239,9 +239,11 @@ class CliMenu
 
         $frame->newLine(2);
 
-        $frame->addRows($this->drawMenuItem(new LineBreakItem()));
-        $frame->addRows($this->drawMenuItem(new StaticItem($this->title)));
-        $frame->addRows($this->drawMenuItem(new LineBreakItem($this->style->getTitleSeparator())));
+        if ($this->title) {
+            $frame->addRows($this->drawMenuItem(new LineBreakItem()));
+            $frame->addRows($this->drawMenuItem(new StaticItem($this->title)));
+            $frame->addRows($this->drawMenuItem(new LineBreakItem($this->style->getTitleSeparator())));
+        }
 
         array_map(function ($item, $index) use ($frame) {
             $frame->addRows($this->drawMenuItem($item, $index === $this->selectedItem));

--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -59,16 +59,8 @@ class CliMenu
      */
     private $currentFrame;
 
-    /**
-     * @param string $title
-     * @param array $items
-     * @param TerminalInterface|null $terminal
-     * @param MenuStyle|null $style
-     *
-     * @throws InvalidTerminalException
-     */
     public function __construct(
-        $title,
+        string $title,
         array $items,
         TerminalInterface $terminal = null,
         MenuStyle $style = null
@@ -86,7 +78,7 @@ class CliMenu
      *
      * @throws InvalidTerminalException
      */
-    protected function configureTerminal()
+    protected function configureTerminal() : void
     {
         $this->assertTerminalIsValidTTY();
 
@@ -100,7 +92,7 @@ class CliMenu
      *
      * @throws InvalidTerminalException
      */
-    protected function tearDownTerminal()
+    protected function tearDownTerminal() : void
     {
         $this->assertTerminalIsValidTTY();
 
@@ -108,7 +100,7 @@ class CliMenu
         $this->terminal->enableCursor();
     }
 
-    private function assertTerminalIsValidTTY()
+    private function assertTerminalIsValidTTY() : void
     {
         if (!$this->terminal->isTTY()) {
             throw new InvalidTerminalException(
@@ -117,44 +109,30 @@ class CliMenu
         }
     }
 
-    /**
-     * @param CliMenu $parent
-     */
-    public function setParent(CliMenu $parent)
+    public function setParent(CliMenu $parent) : void
     {
         $this->parent = $parent;
     }
 
-    /**
-     * @return CliMenu|null
-     */
-    public function getParent()
+    public function getParent() : ?CliMenu
     {
         return $this->parent;
     }
 
-    /**
-     * @return TerminalInterface
-     */
-    public function getTerminal()
+    public function getTerminal() : TerminalInterface
     {
         return $this->terminal;
     }
 
-    /**
-     * @return bool
-     */
-    public function isOpen()
+    public function isOpen() : bool
     {
         return $this->open;
     }
 
     /**
-     * Add a new Item to the listing
-     *
-     * @param MenuItemInterface $item
+     * Add a new Item to the menu
      */
-    public function addItem(MenuItemInterface $item)
+    public function addItem(MenuItemInterface $item) : void
     {
         $this->items[] = $item;
         
@@ -166,7 +144,7 @@ class CliMenu
     /**
      * Set the selected pointer to the first selectable item
      */
-    private function selectFirstItem()
+    private function selectFirstItem() : void
     {
         foreach ($this->items as $key => $item) {
             if ($item->canSelect()) {
@@ -179,7 +157,7 @@ class CliMenu
     /**
      * Display menu and capture input
      */
-    private function display()
+    private function display() : void
     {
         $this->draw();
 
@@ -199,10 +177,8 @@ class CliMenu
 
     /**
      * Move the selection in a given direction, up / down
-     *
-     * @param $direction
      */
-    protected function moveSelection($direction)
+    protected function moveSelection(string $direction) : void
     {
         do {
             $itemKeys = array_keys($this->items);
@@ -221,10 +197,7 @@ class CliMenu
         } while (!$this->getSelectedItem()->canSelect());
     }
 
-    /**
-     * @return MenuItemInterface
-     */
-    public function getSelectedItem()
+    public function getSelectedItem() : MenuItemInterface
     {
         return $this->items[$this->selectedItem];
     }
@@ -232,7 +205,7 @@ class CliMenu
     /**
      * Execute the current item
      */
-    protected function executeCurrentItem()
+    protected function executeCurrentItem() : void
     {
         $item = $this->getSelectedItem();
 
@@ -245,7 +218,7 @@ class CliMenu
     /**
      * Redraw the menu
      */
-    public function redraw()
+    public function redraw() : void
     {
         if (!$this->isOpen()) {
             throw new MenuNotOpenException;
@@ -257,7 +230,7 @@ class CliMenu
     /**
      * Draw the menu to STDOUT
      */
-    protected function draw()
+    protected function draw() : void
     {
         $this->terminal->clean();
         $this->terminal->moveCursorToTop();
@@ -266,11 +239,9 @@ class CliMenu
 
         $frame->newLine(2);
 
-        if (is_string($this->title)) {
-            $frame->addRows($this->drawMenuItem(new LineBreakItem()));
-            $frame->addRows($this->drawMenuItem(new StaticItem($this->title)));
-            $frame->addRows($this->drawMenuItem(new LineBreakItem($this->style->getTitleSeparator())));
-        }
+        $frame->addRows($this->drawMenuItem(new LineBreakItem()));
+        $frame->addRows($this->drawMenuItem(new StaticItem($this->title)));
+        $frame->addRows($this->drawMenuItem(new LineBreakItem($this->style->getTitleSeparator())));
 
         array_map(function ($item, $index) use ($frame) {
             $frame->addRows($this->drawMenuItem($item, $index === $this->selectedItem));
@@ -289,12 +260,8 @@ class CliMenu
 
     /**
      * Draw a menu item
-     *
-     * @param MenuItemInterface $item
-     * @param bool|false $selected
-     * @return array
      */
-    protected function drawMenuItem(MenuItemInterface $item, $selected = false)
+    protected function drawMenuItem(MenuItemInterface $item, bool $selected = false) : array
     {
         $rows = $item->getRows($this->style, $selected);
 
@@ -323,7 +290,7 @@ class CliMenu
     /**
      * @throws InvalidTerminalException
      */
-    public function open()
+    public function open() : void
     {
         if ($this->isOpen()) {
             return;
@@ -339,7 +306,7 @@ class CliMenu
      *
      * @throws InvalidTerminalException
      */
-    public function close()
+    public function close() : void
     {
         $menu = $this;
 
@@ -351,10 +318,7 @@ class CliMenu
         $this->tearDownTerminal();
     }
 
-    /**
-     * @throws InvalidTerminalException
-     */
-    public function closeThis()
+    public function closeThis() : void
     {
         $this->terminal->clean();
         $this->terminal->moveCursorToTop();
@@ -364,17 +328,14 @@ class CliMenu
     /**
      * @return MenuItemInterface[]
      */
-    public function getItems()
+    public function getItems() : array
     {
         return $this->items;
     }
 
-    /**
-     * @param MenuItemInterface $item
-     */
-    public function removeItem(MenuItemInterface $item)
+    public function removeItem(MenuItemInterface $item) : void
     {
-        $key = array_search($item, $this->items);
+        $key = array_search($item, $this->items, true);
 
         if (false === $key) {
             throw new \InvalidArgumentException('Item does not exist in menu');
@@ -384,24 +345,17 @@ class CliMenu
         $this->items = array_values($this->items);
     }
 
-    /**
-     * @return MenuStyle
-     */
-    public function getStyle()
+    public function getStyle() : MenuStyle
     {
         return $this->style;
     }
 
-    public function getCurrentFrame()
+    public function getCurrentFrame() : Frame
     {
         return $this->currentFrame;
     }
 
-    /**
-     * @param string $text
-     * @return Flash
-     */
-    public function flash($text)
+    public function flash(string $text) : Flash
     {
         if (strpos($text, "\n") !== false) {
             throw new \InvalidArgumentException;
@@ -414,11 +368,7 @@ class CliMenu
         return new Flash($this, $style, $this->terminal, $text);
     }
 
-    /**
-     * @param string $text
-     * @return Confirm
-     */
-    public function confirm($text)
+    public function confirm($text) : Confirm
     {
         if (strpos($text, "\n") !== false) {
             throw new \InvalidArgumentException;

--- a/src/CliMenuBuilder.php
+++ b/src/CliMenuBuilder.php
@@ -64,7 +64,7 @@ class CliMenuBuilder
     /**
      * @var string
      */
-    private $menuTitle;
+    private $menuTitle = null;
 
     /**
      * @var bool
@@ -373,7 +373,7 @@ class CliMenuBuilder
         $this->style['displaysExtra'] = $this->itemsHaveExtra($menuItems);
 
         $menu = new CliMenu(
-            $this->menuTitle ?: false,
+            $this->menuTitle,
             $menuItems,
             $this->terminal,
             $this->getMenuStyle()

--- a/src/CliMenuBuilder.php
+++ b/src/CliMenuBuilder.php
@@ -76,9 +76,6 @@ class CliMenuBuilder
      */
     private $disabled = false;
 
-    /**
-     * @param CliMenuBuilder|null $parent
-     */
     public function __construct(CliMenuBuilder $parent = null)
     {
         $this->parent   = $parent;
@@ -86,51 +83,32 @@ class CliMenuBuilder
         $this->style    = MenuStyle::getDefaultStyleValues();
     }
 
-    /**
-     * @param string $title
-     * @return $this
-     */
-    public function setTitle($title)
+    public function setTitle(string $title) : self
     {
-        Assertion::string($title);
-
         $this->menuTitle = $title;
 
         return $this;
     }
 
-    /**
-     * @param MenuItemInterface $item
-     * @return $this
-     */
-    public function addMenuItem(MenuItemInterface $item)
+    public function addMenuItem(MenuItemInterface $item) : self
     {
         $this->menuItems[] = $item;
 
         return $this;
     }
 
-    /**
-     * @param string $text
-     * @param callable $itemCallable
-     * @param bool $showItemExtra
-     * @param bool $disabled
-     * @return $this
-     */
-    public function addItem($text, callable $itemCallable, $showItemExtra = false, $disabled = false)
-    {
-        Assertion::string($text);
-
+    public function addItem(
+        string $text,
+        callable $itemCallable,
+        bool $showItemExtra = false,
+        bool $disabled = false
+    ) : self {
         $this->addMenuItem(new SelectableItem($text, $itemCallable, $showItemExtra, $disabled));
 
         return $this;
     }
 
-    /**
-     * @param array $items
-     * @return $this
-     */
-    public function addItems(array $items)
+    public function addItems(array $items) : self
     {
         foreach ($items as $item) {
             $this->addItem(...$item);
@@ -139,44 +117,22 @@ class CliMenuBuilder
         return $this;
     }
 
-    /**
-     * @param string $text
-     * @return $this
-     */
-    public function addStaticItem($text)
+    public function addStaticItem(string $text) : self
     {
-        Assertion::string($text);
-
         $this->addMenuItem(new StaticItem($text));
 
         return $this;
     }
 
-    /**
-     * @param string $breakChar
-     * @param int $lines
-     * @return $this
-     */
-    public function addLineBreak($breakChar = ' ', $lines = 1)
+    public function addLineBreak(string $breakChar = ' ', int $lines = 1) : self
     {
-        Assertion::string($breakChar);
-        Assertion::integer($lines);
-
         $this->addMenuItem(new LineBreakItem($breakChar, $lines));
 
         return $this;
     }
 
-    /**
-     * @param string $art
-     * @param string $position
-     * @return $this
-     */
-    public function addAsciiArt($art, $position = AsciiArtItem::POSITION_CENTER)
+    public function addAsciiArt(string $art, string $position = AsciiArtItem::POSITION_CENTER) : self
     {
-        Assertion::string($art);
-        Assertion::string($position);
-
         $asciiArtItem = new AsciiArtItem($art, $position);
 
         if ($asciiArtItem->getArtLength() <= $this->getMenuStyle()->getContentWidth()) {
@@ -187,13 +143,10 @@ class CliMenuBuilder
     }
 
     /**
-     * @param string $id ID to reference and retrieve sub-menu
-     * @return CliMenuBuilder
+     * Add a submenu with a string identifier
      */
-    public function addSubMenu($id)
+    public function addSubMenu(string $id) : CliMenuBuilder
     {
-        Assertion::string($id);
-
         $this->menuItems[]   = $id;
         $this->subMenus[$id] = new static($this);
 
@@ -202,10 +155,10 @@ class CliMenuBuilder
 
     /**
      * Disable a submenu
+     *
      * @throws \InvalidArgumentException
-     * @return $this
      */
-    public function disableMenu()
+    public function disableMenu() : self
     {
         if (!$this->parent) {
             throw new \InvalidArgumentException(
@@ -218,41 +171,26 @@ class CliMenuBuilder
         return $this;
     }
 
-    /**
-     * @return bool
-     */
-    public function isMenuDisabled()
+    public function isMenuDisabled() : bool
     {
         return $this->disabled;
     }
 
-    /**
-     * @param string $goBackButtonTest
-     * @return $this
-     */
-    public function setGoBackButtonText($goBackButtonTest)
+    public function setGoBackButtonText(string $goBackButtonTest) : self
     {
         $this->goBackButtonText = $goBackButtonTest;
         
         return $this;
     }
 
-    /**
-     * @param string $exitButtonText
-     * @return $this
-     */
-    public function setExitButtonText($exitButtonText)
+    public function setExitButtonText(string $exitButtonText) : self
     {
         $this->exitButtonText = $exitButtonText;
         
         return $this;
     }
 
-    /**
-     * @param string $colour
-     * @return $this
-     */
-    public function setBackgroundColour($colour)
+    public function setBackgroundColour(string $colour) : self
     {
         Assertion::inArray($colour, MenuStyle::getAvailableColours());
 
@@ -261,11 +199,7 @@ class CliMenuBuilder
         return $this;
     }
 
-    /**
-     * @param string $colour
-     * @return $this
-     */
-    public function setForegroundColour($colour)
+    public function setForegroundColour(string $colour) : self
     {
         Assertion::inArray($colour, MenuStyle::getAvailableColours());
 
@@ -274,111 +208,62 @@ class CliMenuBuilder
         return $this;
     }
 
-    /**
-     * @param int $width
-     * @return $this
-     */
-    public function setWidth($width)
+    public function setWidth(int $width) : self
     {
-        Assertion::integer($width);
-
         $this->style['width'] = $width;
 
         return $this;
     }
 
-    /**
-     * @param int $padding
-     * @return $this
-     */
-    public function setPadding($padding)
+    public function setPadding(int $padding) : self
     {
-        Assertion::integer($padding);
-
         $this->style['padding'] = $padding;
 
         return $this;
     }
 
-    /**
-     * @param int $margin
-     * @return $this
-     */
-    public function setMargin($margin)
+    public function setMargin(int $margin) : self
     {
-        Assertion::integer($margin);
-
         $this->style['margin'] = $margin;
 
         return $this;
     }
 
-    /**
-     * @param string $marker
-     * @return $this
-     */
-    public function setUnselectedMarker($marker)
+    public function setUnselectedMarker(string $marker) : self
     {
-        Assertion::string($marker);
-
         $this->style['unselectedMarker'] = $marker;
 
         return $this;
     }
 
-    /**
-     * @param string $marker
-     * @return $this
-     */
-    public function setSelectedMarker($marker)
+    public function setSelectedMarker(string $marker) : self
     {
-        Assertion::string($marker);
-
         $this->style['selectedMarker'] = $marker;
 
         return $this;
     }
 
-    /**
-     * @param string $extra
-     * @return $this
-     */
-    public function setItemExtra($extra)
+    public function setItemExtra(string $extra) : self
     {
-        Assertion::string($extra);
-
         $this->style['itemExtra'] = $extra;
 
         return $this;
     }
 
-    /**
-     * @param string $separator
-     * @return $this
-     */
-    public function setTitleSeparator($separator)
+    public function setTitleSeparator(string $separator) : self
     {
-        Assertion::string($separator);
-
         $this->style['titleSeparator'] = $separator;
 
         return $this;
     }
 
-    /**
-     * @param TerminalInterface $terminal
-     * @return $this
-     */
-    public function setTerminal(TerminalInterface $terminal)
+    public function setTerminal(TerminalInterface $terminal) : self
     {
         $this->terminal = $terminal;
         return $this;
     }
 
-    /**
-     * @return array
-     */
-    private function getDefaultItems()
+    private function getDefaultItems() : array
     {
         $actions = [];
         if ($this->parent) {
@@ -389,21 +274,14 @@ class CliMenuBuilder
         return $actions;
     }
 
-    /**
-     * @return $this
-     */
-    public function disableDefaultItems()
+    public function disableDefaultItems() : self
     {
         $this->disableDefaultItems = true;
 
         return $this;
     }
 
-    /**
-     * @param array $items
-     * @return bool
-     */
-    private function itemsHaveExtra(array $items)
+    private function itemsHaveExtra(array $items) : bool
     {
         return !empty(array_filter($items, function (MenuItemInterface $item) {
             return $item->showsItemExtra();
@@ -413,10 +291,8 @@ class CliMenuBuilder
     /**
      * Recursively drop back to the parents menu style
      * when the current menu has a parent and has no changes
-     *
-     * @return MenuStyle
      */
-    private function getMenuStyle()
+    private function getMenuStyle() : MenuStyle
     {
         if (null === $this->parent) {
             return $this->buildStyle();
@@ -429,10 +305,7 @@ class CliMenuBuilder
         return $this->parent->getMenuStyle();
     }
 
-    /**
-     * @return MenuStyle
-     */
-    private function buildStyle()
+    private function buildStyle() : MenuStyle
     {
         return (new MenuStyle($this->terminal))
             ->setFg($this->style['fg'])
@@ -450,10 +323,9 @@ class CliMenuBuilder
     /**
      * Return to parent builder
      *
-     * @return CliMenuBuilder
      * @throws RuntimeException
      */
-    public function end()
+    public function end() : CliMenuBuilder
     {
         if (null === $this->parent) {
             throw new RuntimeException('No parent builder to return to');
@@ -463,11 +335,9 @@ class CliMenuBuilder
     }
 
     /**
-     * @param string $id
-     * @return CliMenu
      * @throws RuntimeException
      */
-    public function getSubMenu($id)
+    public function getSubMenu(string $id) : CliMenu
     {
         if (false === $this->isBuilt) {
             throw new RuntimeException(sprintf('Menu: "%s" cannot be retrieved until menu has been built', $id));
@@ -476,11 +346,7 @@ class CliMenuBuilder
         return $this->subMenus[$id];
     }
 
-    /**
-     * @param array $items
-     * @return array
-     */
-    private function buildSubMenus(array $items)
+    private function buildSubMenus(array $items) : array
     {
         return array_map(function ($item) {
             if (!is_string($item)) {
@@ -494,10 +360,7 @@ class CliMenuBuilder
         }, $items);
     }
 
-    /**
-     * @return CliMenu
-     */
-    public function build()
+    public function build() : CliMenu
     {
         $this->isBuilt = true;
 

--- a/src/CliMenuBuilder.php
+++ b/src/CliMenuBuilder.php
@@ -16,9 +16,6 @@ use Assert\Assertion;
 use RuntimeException;
 
 /**
- * Class CliMenuBuilder
- *
- * @package PhpSchool\CliMenu
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  * @author Aydin Hassan <aydin@hotmail.com>
  */

--- a/src/CliMenuBuilder.php
+++ b/src/CliMenuBuilder.php
@@ -32,7 +32,12 @@ class CliMenuBuilder
     private $parent;
     
     /**
-     * @var self[]|CliMenu[]
+     * @var self[]
+     */
+    private $subMenuBuilders = [];
+
+    /**
+     * @var CliMenu[]
      */
     private $subMenus = [];
 
@@ -147,10 +152,10 @@ class CliMenuBuilder
      */
     public function addSubMenu(string $id) : CliMenuBuilder
     {
-        $this->menuItems[]   = $id;
-        $this->subMenus[$id] = new static($this);
+        $this->menuItems[]          = $id;
+        $this->subMenuBuilders[$id] = new static($this);
 
-        return $this->subMenus[$id];
+        return $this->subMenuBuilders[$id];
     }
 
     /**
@@ -353,7 +358,7 @@ class CliMenuBuilder
                 return $item;
             }
 
-            $menuBuilder           = $this->subMenus[$item];
+            $menuBuilder           = $this->subMenuBuilders[$item];
             $this->subMenus[$item] = $menuBuilder->build();
 
             return new MenuMenuItem($item, $this->subMenus[$item], $menuBuilder->isMenuDisabled());

--- a/src/Dialogue/Confirm.php
+++ b/src/Dialogue/Confirm.php
@@ -10,10 +10,8 @@ class Confirm extends Dialogue
 
     /**
      * Display confirmation with a button with the given text
-     *
-     * @param string $confirmText
      */
-    public function display($confirmText = 'OK')
+    public function display(string $confirmText = 'OK') : void
     {
         $this->assertMenuOpen();
 

--- a/src/Dialogue/Dialogue.php
+++ b/src/Dialogue/Dialogue.php
@@ -42,13 +42,7 @@ abstract class Dialogue
      */
     protected $y;
 
-    /**
-     * @param CliMenu $parentMenu
-     * @param MenuStyle $menuStyle
-     * @param TerminalInterface $terminal
-     * @param string $text
-     */
-    public function __construct(CliMenu $parentMenu, MenuStyle $menuStyle, TerminalInterface $terminal, $text)
+    public function __construct(CliMenu $parentMenu, MenuStyle $menuStyle, TerminalInterface $terminal, string $text)
     {
         $this->style        = $menuStyle;
         $this->terminal     = $terminal;
@@ -61,7 +55,7 @@ abstract class Dialogue
     /**
      * @throws MenuNotOpenException
      */
-    protected function assertMenuOpen()
+    protected function assertMenuOpen() : void
     {
         if (!$this->parentMenu->isOpen()) {
             throw new MenuNotOpenException;
@@ -71,7 +65,7 @@ abstract class Dialogue
     /**
      * Calculate the co-ordinates to write the messages
      */
-    protected function calculateCoordinates()
+    protected function calculateCoordinates() : void
     {
         //y
         $textLines          = count(explode("\n", $this->text)) + 2;
@@ -87,7 +81,7 @@ abstract class Dialogue
     /**
      * Write an empty row
      */
-    protected function emptyRow()
+    protected function emptyRow() : void
     {
         $this->write(
             sprintf(
@@ -103,20 +97,14 @@ abstract class Dialogue
 
     /**
      * Write some text at a particular column
-     *
-     * @param int $column
-     * @param string $text
      */
-    protected function write($text, $column = null)
+    protected function write(string $text, int $column = null) : void
     {
         $this->terminal->moveCursorToColumn($column ?: $this->x);
         echo $text;
     }
 
-    /**
-     * @return MenuStyle
-     */
-    public function getStyle()
+    public function getStyle() : MenuStyle
     {
         return $this->style;
     }

--- a/src/Dialogue/Flash.php
+++ b/src/Dialogue/Flash.php
@@ -11,7 +11,7 @@ class Flash extends Dialogue
      * Flash a message on top of the menu which
      * disappears on any keystroke.
      */
-    public function display()
+    public function display() : void
     {
         $this->assertMenuOpen();
 

--- a/src/Exception/InvalidTerminalException.php
+++ b/src/Exception/InvalidTerminalException.php
@@ -3,9 +3,6 @@
 namespace PhpSchool\CliMenu\Exception;
 
 /**
- * Class InvalidTerminalException
- *
- * @package PhpSchool\CliMenu\Exception
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
 class InvalidTerminalException extends \Exception

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -15,46 +15,31 @@ class Frame implements \Countable
      */
     private $rows = [];
 
-    /**
-     * @param int $count
-     */
-    public function newLine($count = 1)
+    public function newLine(int $count = 1) : void
     {
         foreach (range(1, $count) as $i) {
             $this->rows[] = "\n";
         }
     }
 
-    /**
-     * @param array $rows
-     */
-    public function addRows(array $rows = [])
+    public function addRows(array $rows = []) : void
     {
         foreach ($rows as $row) {
             $this->rows[] = $row;
         }
     }
 
-    /**
-     * @param string $row
-     */
-    public function addRow($row)
+    public function addRow(string $row) : void
     {
         $this->rows[] = $row;
     }
 
-    /**
-     * @return int
-     */
-    public function count()
+    public function count() : int
     {
         return count($this->rows);
     }
 
-    /**
-     * @return array
-     */
-    public function getRows()
+    public function getRows() : array
     {
         return $this->rows;
     }

--- a/src/MenuItem/AsciiArtItem.php
+++ b/src/MenuItem/AsciiArtItem.php
@@ -32,13 +32,8 @@ class AsciiArtItem implements MenuItemInterface
      */
     private $artLength;
 
-    /**
-     * @param string $text
-     * @param string $position
-     */
-    public function __construct($text, $position = self::POSITION_CENTER)
+    public function __construct(string $text, string $position = self::POSITION_CENTER)
     {
-        Assertion::string($text);
         Assertion::inArray($position, [self::POSITION_CENTER, self::POSITION_RIGHT, self::POSITION_LEFT]);
         
         $this->text      = $text;
@@ -48,12 +43,8 @@ class AsciiArtItem implements MenuItemInterface
 
     /**
      * The output text for the item
-     *
-     * @param MenuStyle $style
-     * @param bool $selected
-     * @return array
      */
-    public function getRows(MenuStyle $style, $selected = false)
+    public function getRows(MenuStyle $style, bool $selected = false) : array
     {
         return array_map(function ($row) use ($style) {
             $length = mb_strlen($row);
@@ -85,68 +76,56 @@ class AsciiArtItem implements MenuItemInterface
 
     /**
      * Can the item be selected
-     *
-     * @return bool
      */
-    public function canSelect()
+    public function canSelect() : bool
     {
         return false;
     }
 
     /**
      * Execute the items callable if required
-     *
-     * @return void
      */
-    public function getSelectAction()
+    public function getSelectAction() : ?callable
     {
-        return;
+        return null;
     }
 
     /**
      * Return the raw string of text
-     *
-     * @return string
      */
-    public function getText()
+    public function getText() : string
     {
         return $this->text;
     }
 
     /**
      * Return the length of the art
-     *
-     * @return int
      */
-    public function getArtLength()
+    public function getArtLength() : int
     {
         return $this->artLength;
     }
 
     /**
      * Whether or not the menu item is showing the menustyle extra value
-     *
-     * @return bool
      */
-    public function showsItemExtra()
+    public function showsItemExtra() : bool
     {
         return false;
     }
 
     /**
      * Enable showing item extra
-     *
      */
-    public function showItemExtra()
+    public function showItemExtra() : void
     {
         //noop
     }
 
     /**
      * Disable showing item extra
-     *
      */
-    public function hideItemExtra()
+    public function hideItemExtra() : void
     {
         //noop
     }

--- a/src/MenuItem/AsciiArtItem.php
+++ b/src/MenuItem/AsciiArtItem.php
@@ -6,9 +6,6 @@ use Assert\Assertion;
 use PhpSchool\CliMenu\MenuStyle;
 
 /**
- * Class AsciiArtItem
- *
- * @package PhpSchool\CliMenu\MenuItem
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
 class AsciiArtItem implements MenuItemInterface

--- a/src/MenuItem/LineBreakItem.php
+++ b/src/MenuItem/LineBreakItem.php
@@ -6,9 +6,6 @@ use Assert\Assertion;
 use PhpSchool\CliMenu\MenuStyle;
 
 /**
- * Class LineBreakItem
- *
- * @package PhpSchool\CliMenu\MenuItem
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
 class LineBreakItem implements MenuItemInterface

--- a/src/MenuItem/LineBreakItem.php
+++ b/src/MenuItem/LineBreakItem.php
@@ -20,29 +20,16 @@ class LineBreakItem implements MenuItemInterface
      */
     private $lines;
 
-    /**
-     * Initialise text item
-     *
-     * @param string $breakChar
-     * @param int    $lines
-     */
-    public function __construct($breakChar = ' ', $lines = 1)
+    public function __construct(string $breakChar = ' ', int $lines = 1)
     {
-        Assertion::string($breakChar);
-        Assertion::integer($lines);
-        
         $this->breakChar = $breakChar;
         $this->lines     = $lines;
     }
 
     /**
      * The output text for the item
-     *
-     * @param MenuStyle $style
-     * @param bool $selected
-     * @return array
      */
-    public function getRows(MenuStyle $style, $selected = false)
+    public function getRows(MenuStyle $style, bool $selected = false) : array
     {
         return explode(
             "\n",
@@ -55,58 +42,48 @@ class LineBreakItem implements MenuItemInterface
 
     /**
      * Can the item be selected
-     *
-     * @return bool
      */
-    public function canSelect()
+    public function canSelect() : bool
     {
         return false;
     }
 
     /**
      * Execute the items callable if required
-     *
-     * @return callable|void
      */
-    public function getSelectAction()
+    public function getSelectAction() : ?callable
     {
-        return;
+        return null;
     }
 
     /**
      * Return the raw string of text
-     *
-     * @return string
      */
-    public function getText()
+    public function getText() : string
     {
         return $this->breakChar;
     }
 
     /**
      * Whether or not the menu item is showing the menustyle extra value
-     *
-     * @return bool
      */
-    public function showsItemExtra()
+    public function showsItemExtra() : bool
     {
         return false;
     }
 
     /**
      * Enable showing item extra
-     *
      */
-    public function showItemExtra()
+    public function showItemExtra() : void
     {
         //noop
     }
 
     /**
      * Disable showing item extra
-     *
      */
-    public function hideItemExtra()
+    public function hideItemExtra() : void
     {
         //noop
     }

--- a/src/MenuItem/MenuItemInterface.php
+++ b/src/MenuItem/MenuItemInterface.php
@@ -11,50 +11,36 @@ interface MenuItemInterface
 {
     /**
      * The output text for the item
-     *
-     * @param MenuStyle $style
-     * @param bool $selected
-     * @return array
      */
-    public function getRows(MenuStyle $style, $selected = false);
+    public function getRows(MenuStyle $style, bool $selected = false) : array;
 
     /**
      * Return the raw string of text
-     *
-     * @return string
      */
-    public function getText();
+    public function getText() : string;
 
     /**
      * Can the item be selected
-     *
-     * @return bool
      */
-    public function canSelect();
+    public function canSelect() : bool;
 
     /**
      * Execute the items callable if required
-     *
-     * @return callable|void
      */
-    public function getSelectAction();
+    public function getSelectAction() : ?callable;
 
     /**
      * Whether or not the menu item is showing the menustyle extra value
-     *
-     * @return bool
      */
-    public function showsItemExtra();
+    public function showsItemExtra() : bool;
 
     /**
      * Enable showing item extra
-     *
      */
-    public function showItemExtra();
+    public function showItemExtra() : void;
 
     /**
      * Disable showing item extra
-     *
      */
-    public function hideItemExtra();
+    public function hideItemExtra() : void;
 }

--- a/src/MenuItem/MenuItemInterface.php
+++ b/src/MenuItem/MenuItemInterface.php
@@ -5,9 +5,6 @@ namespace PhpSchool\CliMenu\MenuItem;
 use PhpSchool\CliMenu\MenuStyle;
 
 /**
- * Interface MenuItemInterface
- *
- * @package PhpSchool\CliMenu\MenuItem
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
 interface MenuItemInterface

--- a/src/MenuItem/MenuMenuItem.php
+++ b/src/MenuItem/MenuMenuItem.php
@@ -17,15 +17,8 @@ class MenuMenuItem implements MenuItemInterface
      */
     private $subMenu;
 
-    /**
-     * @param string $text
-     * @param CliMenu $subMenu
-     * @param bool $disabled
-     */
-    public function __construct($text, CliMenu $subMenu, $disabled = false)
+    public function __construct(string $text, CliMenu $subMenu, bool $disabled = false)
     {
-        Assertion::string($text);
-        
         $this->text     = $text;
         $this->subMenu  = $subMenu;
         $this->disabled = $disabled;
@@ -33,29 +26,24 @@ class MenuMenuItem implements MenuItemInterface
 
     /**
      * Execute the items callable if required
-     *
-     * @return callable
      */
-    public function getSelectAction()
+    public function getSelectAction() : ?callable
     {
         return [$this, 'showSubMenu'];
     }
 
     /**
      * Return the raw string of text
-     *
-     * @return string
      */
-    public function getText()
+    public function getText() : string
     {
         return $this->text;
     }
 
     /**
      * Display the sub menu
-     * @param CliMenu $parentMenu
      */
-    public function showSubMenu(CliMenu $parentMenu)
+    public function showSubMenu(CliMenu $parentMenu) : void
     {
         $parentMenu->closeThis();
         $this->subMenu->open();

--- a/src/MenuItem/MenuMenuItem.php
+++ b/src/MenuItem/MenuMenuItem.php
@@ -6,9 +6,6 @@ use Assert\Assertion;
 use PhpSchool\CliMenu\CliMenu;
 
 /**
- * Class MenuMenuItem
- *
- * @package PhpSchool\CliMenu\MenuItem
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
 class MenuMenuItem implements MenuItemInterface

--- a/src/MenuItem/SelectableItem.php
+++ b/src/MenuItem/SelectableItem.php
@@ -5,9 +5,6 @@ namespace PhpSchool\CliMenu\MenuItem;
 use Assert\Assertion;
 
 /**
- * Class SelectableItem
- *
- * @package PhpSchool\CliMenu\MenuItem
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
 class SelectableItem implements MenuItemInterface

--- a/src/MenuItem/SelectableItem.php
+++ b/src/MenuItem/SelectableItem.php
@@ -2,8 +2,6 @@
 
 namespace PhpSchool\CliMenu\MenuItem;
 
-use Assert\Assertion;
-
 /**
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
@@ -16,38 +14,30 @@ class SelectableItem implements MenuItemInterface
      */
     private $selectAction;
 
-    /**
-     * @param string $text
-     * @param callable $selectAction
-     * @param bool $showItemExtra
-     * @param bool $disabled
-     */
-    public function __construct($text, callable $selectAction, $showItemExtra = false, $disabled = false)
-    {
-        Assertion::string($text);
-     
+    public function __construct(
+        string $text,
+        callable $selectAction,
+        bool $showItemExtra = false,
+        bool $disabled = false
+    ) {
         $this->text          = $text;
         $this->selectAction  = $selectAction;
-        $this->showItemExtra = (bool) $showItemExtra;
+        $this->showItemExtra = $showItemExtra;
         $this->disabled      = $disabled;
     }
 
     /**
      * Execute the items callable if required
-     *
-     * @return callable|void
      */
-    public function getSelectAction()
+    public function getSelectAction() : ?callable
     {
         return $this->selectAction;
     }
 
     /**
      * Return the raw string of text
-     *
-     * @return string
      */
-    public function getText()
+    public function getText() : string
     {
         return $this->text;
     }

--- a/src/MenuItem/SelectableTrait.php
+++ b/src/MenuItem/SelectableTrait.php
@@ -27,12 +27,8 @@ trait SelectableTrait
 
     /**
      * The output text for the item
-     *
-     * @param MenuStyle $style
-     * @param bool $selected
-     * @return array
      */
-    public function getRows(MenuStyle $style, $selected = false)
+    public function getRows(MenuStyle $style, bool $selected = false) : array
     {
         $marker = sprintf("%s ", $style->getMarker($selected));
 
@@ -64,36 +60,29 @@ trait SelectableTrait
 
     /**
      * Can the item be selected
-     *
-     * @return bool
      */
-    public function canSelect()
+    public function canSelect() : bool
     {
         return !$this->disabled;
     }
 
-    /**
-     * @return bool
-     */
-    public function showsItemExtra()
+    public function showsItemExtra() : bool
     {
         return $this->showItemExtra;
     }
 
     /**
      * Enable showing item extra
-     *
      */
-    public function showItemExtra()
+    public function showItemExtra() : void
     {
         $this->showItemExtra = true;
     }
 
     /**
      * Disable showing item extra
-     *
      */
-    public function hideItemExtra()
+    public function hideItemExtra() : void
     {
         $this->showItemExtra = false;
     }

--- a/src/MenuItem/SelectableTrait.php
+++ b/src/MenuItem/SelectableTrait.php
@@ -6,9 +6,6 @@ use PhpSchool\CliMenu\MenuStyle;
 use PhpSchool\CliMenu\Util\StringUtil;
 
 /**
- * Class SelectableTrait
- *
- * @package PhpSchool\CliMenu\MenuItem
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
 trait SelectableTrait

--- a/src/MenuItem/SelectableTrait.php
+++ b/src/MenuItem/SelectableTrait.php
@@ -45,7 +45,7 @@ trait SelectableTrait
             )
         );
 
-        return array_map(function ($row, $key) use ($style, $marker, $length) {
+        return array_map(function ($row, $key) use ($style, $length) {
             $text = $this->disabled ? $style->getDisabledItemText($row) : $row;
 
             if ($key === 0) {

--- a/src/MenuItem/StaticItem.php
+++ b/src/MenuItem/StaticItem.php
@@ -7,9 +7,6 @@ use PhpSchool\CliMenu\MenuStyle;
 use PhpSchool\CliMenu\Util\StringUtil;
 
 /**
- * Class StaticItem
- *
- * @package PhpSchool\CliMenu\MenuItem
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
 class StaticItem implements MenuItemInterface

--- a/src/MenuItem/StaticItem.php
+++ b/src/MenuItem/StaticItem.php
@@ -16,82 +16,63 @@ class StaticItem implements MenuItemInterface
      */
     private $text;
 
-    /**
-     * @param string $text
-     */
-    public function __construct($text)
+    public function __construct(string $text)
     {
-        Assertion::string($text);
-        
         $this->text = $text;
     }
 
     /**
      * The output text for the item
-     *
-     * @param MenuStyle $style
-     * @param bool $selected
-     * @return array
      */
-    public function getRows(MenuStyle $style, $selected = false)
+    public function getRows(MenuStyle $style, bool $selected = false) : array
     {
         return explode("\n", StringUtil::wordwrap($this->text, $style->getContentWidth()));
     }
 
     /**
      * Can the item be selected
-     *
-     * @return bool
      */
-    public function canSelect()
+    public function canSelect() : bool
     {
         return false;
     }
 
     /**
      * Execute the items callable if required
-     *
-     * @return void
      */
-    public function getSelectAction()
+    public function getSelectAction() : ?callable
     {
-        return;
+        return null;
     }
 
     /**
      * Return the raw string of text
-     *
-     * @return string
      */
-    public function getText()
+    public function getText() : string
     {
         return $this->text;
     }
 
     /**
      * Whether or not the menu item is showing the menustyle extra value
-     *
-     * @return bool
      */
-    public function showsItemExtra()
+    public function showsItemExtra() : bool
     {
         return false;
     }
 
     /**
      * Enable showing item extra
-     *
      */
-    public function showItemExtra()
+    public function showItemExtra() : void
     {
         //noop
     }
 
     /**
      * Disable showing item extra
-     *
      */
-    public function hideItemExtra()
+    public function hideItemExtra() : void
     {
         //noop
     }

--- a/src/MenuStyle.php
+++ b/src/MenuStyle.php
@@ -9,9 +9,6 @@ use PhpSchool\CliMenu\Terminal\TerminalInterface;
 //TODO: B/W fallback
 
 /**
- * Class MenuStyle
- *
- * @package PhpSchool\CliMenu
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
 class MenuStyle

--- a/src/MenuStyle.php
+++ b/src/MenuStyle.php
@@ -91,10 +91,7 @@ class MenuStyle
         'titleSeparator' => '=',
     ];
 
-    /**
-     * @return array
-     */
-    public static function getDefaultStyleValues()
+    public static function getDefaultStyleValues() : array
     {
         return static::$defaultStyleValues;
     }
@@ -143,8 +140,6 @@ class MenuStyle
 
     /**
      * Initialise style
-     *
-     * @param TerminalInterface $terminal
      */
     public function __construct(TerminalInterface $terminal = null)
     {
@@ -162,19 +157,12 @@ class MenuStyle
         $this->setTitleSeparator(static::$defaultStyleValues['titleSeparator']);
     }
 
-    /**
-     * @return array
-     */
-    public static function getAvailableColours()
+    public static function getAvailableColours() : array
     {
         return array_keys(self::$availableBackgroundColors);
     }
 
-    /**
-     * @param string $text
-     * @return string
-     */
-    public function getDisabledItemText($text)
+    public function getDisabledItemText(string $text) : string
     {
         return sprintf(
             "\033[%sm%s\033[%sm",
@@ -186,10 +174,8 @@ class MenuStyle
     
     /**
      * Get the colour code set for Bg and Fg
-     *
-     * @return string
      */
-    public function getSelectedSetCode()
+    public function getSelectedSetCode() : string
     {
         return sprintf(
             "\033[%sm",
@@ -202,10 +188,8 @@ class MenuStyle
 
     /**
      * Get the colour unset code for Bg and Fg
-     *
-     * @return string
      */
-    public function getSelectedUnsetCode()
+    public function getSelectedUnsetCode() : string
     {
         return sprintf(
             "\033[%sm",
@@ -218,10 +202,8 @@ class MenuStyle
 
     /**
      * Get the inverted colour code
-     *
-     * @return string
      */
-    public function getUnselectedSetCode()
+    public function getUnselectedSetCode() : string
     {
         return sprintf(
             "\033[%sm",
@@ -234,10 +216,8 @@ class MenuStyle
 
     /**
      * Get the inverted colour unset code
-     *
-     * @return string
      */
-    public function getUnselectedUnsetCode()
+    public function getUnselectedUnsetCode() : string
     {
         return sprintf(
             "\033[%sm",
@@ -251,62 +231,41 @@ class MenuStyle
     /**
      * Calculate the contents width
      */
-    protected function calculateContentWidth()
+    protected function calculateContentWidth() : void
     {
         $this->contentWidth = $this->width - ($this->padding*2) - ($this->margin*2);
     }
 
-    /**
-     * @return string
-     */
-    public function getFg()
+    public function getFg() : string
     {
         return $this->fg;
     }
 
-    /**
-     * @param string $fg
-     * @return MenuStyle
-     */
-    public function setFg($fg)
+    public function setFg(string $fg) : self
     {
         $this->fg = $fg;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getBg()
+    public function getBg() : string
     {
         return $this->bg;
     }
 
-    /**
-     * @param string $bg
-     * @return MenuStyle
-     */
-    public function setBg($bg)
+    public function setBg(string $bg) : self
     {
         $this->bg = $bg;
 
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getWidth()
+    public function getWidth() : int
     {
         return $this->width;
     }
 
-    /**
-     * @param int $width
-     * @return MenuStyle
-     */
-    public function setWidth($width)
+    public function setWidth(int $width) : self
     {
         $availableWidth = $this->terminal->getWidth() - ($this->margin * 2) - ($this->padding * 2);
 
@@ -320,19 +279,12 @@ class MenuStyle
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getPadding()
+    public function getPadding() : int
     {
         return $this->padding;
     }
 
-    /**
-     * @param int $padding
-     * @return MenuStyle
-     */
-    public function setPadding($padding)
+    public function setPadding(int $padding) : self
     {
         $this->padding = $padding;
 
@@ -341,19 +293,12 @@ class MenuStyle
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getMargin()
+    public function getMargin() : int
     {
         return $this->margin;
     }
 
-    /**
-     * @param int $margin
-     * @return MenuStyle
-     */
-    public function setMargin($margin)
+    public function setMargin(int $margin) : self
     {
         $this->margin = $margin;
 
@@ -362,57 +307,37 @@ class MenuStyle
         return $this;
     }
 
-    /**
-     * @return int
-     */
-    public function getContentWidth()
+    public function getContentWidth() : int
     {
         return $this->contentWidth;
     }
 
     /**
      * Get padding for right had side of content
-     *
-     * @param $contentLength
-     * @return int
      */
-    public function getRightHandPadding($contentLength)
+    public function getRightHandPadding(int $contentLength) : int
     {
         return $this->getContentWidth() - $contentLength + $this->getPadding();
     }
 
-    /**
-     * @return string
-     */
-    public function getSelectedMarker()
+    public function getSelectedMarker() : string
     {
         return $this->selectedMarker;
     }
 
-    /**
-     * @param string $marker
-     * @return $this
-     */
-    public function setSelectedMarker($marker)
+    public function setSelectedMarker(string $marker) : self
     {
         $this->selectedMarker = mb_substr($marker, 0, 1);
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getUnselectedMarker()
+    public function getUnselectedMarker() : string
     {
         return $this->unselectedMarker;
     }
 
-    /**
-     * @param string $marker
-     * @return $this
-     */
-    public function setUnselectedMarker($marker)
+    public function setUnselectedMarker(string $marker) : self
     {
         $this->unselectedMarker = mb_substr($marker, 0, 1);
 
@@ -421,66 +346,42 @@ class MenuStyle
 
     /**
      * Get the correct marker for the item
-     *
-     * @param bool $selected
-     * @return string
      */
-    public function getMarker($selected)
+    public function getMarker(bool $selected) : string
     {
         return $selected ? $this->selectedMarker : $this->unselectedMarker;
     }
 
-    /**
-     * @param string $itemExtra
-     * @return $this
-     */
-    public function setItemExtra($itemExtra)
+    public function setItemExtra(string $itemExtra) : self
     {
         $this->itemExtra = $itemExtra;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getItemExtra()
+    public function getItemExtra() : string
     {
         return $this->itemExtra;
     }
 
-    /**
-     * @return bool
-     */
-    public function getDisplaysExtra()
+    public function getDisplaysExtra() : bool
     {
         return $this->displaysExtra;
     }
 
-    /**
-     * @param bool $displaysExtra
-     * @return $this
-     */
-    public function setDisplaysExtra($displaysExtra)
+    public function setDisplaysExtra(bool $displaysExtra) : self
     {
         $this->displaysExtra = $displaysExtra;
 
         return $this;
     }
 
-    /**
-     * @return string
-     */
-    public function getTitleSeparator()
+    public function getTitleSeparator() : string
     {
         return $this->titleSeparator;
     }
 
-    /**
-     * @param string $actionSeparator
-     * @return $this
-     */
-    public function setTitleSeparator($actionSeparator)
+    public function setTitleSeparator(string $actionSeparator) : self
     {
         $this->titleSeparator = $actionSeparator;
 

--- a/src/Terminal/TerminalFactory.php
+++ b/src/Terminal/TerminalFactory.php
@@ -7,10 +7,7 @@ namespace PhpSchool\CliMenu\Terminal;
  */
 class TerminalFactory
 {
-    /**
-     * @return TerminalInterface
-     */
-    public static function fromSystem()
+    public static function fromSystem() : TerminalInterface
     {
         return new UnixTerminal();
     }

--- a/src/Terminal/TerminalFactory.php
+++ b/src/Terminal/TerminalFactory.php
@@ -3,9 +3,6 @@
 namespace PhpSchool\CliMenu\Terminal;
 
 /**
- * Class TerminalFactory
- *
- * @package PhpSchool\CliMenu\Terminal
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
 class TerminalFactory

--- a/src/Terminal/TerminalInterface.php
+++ b/src/Terminal/TerminalInterface.php
@@ -9,107 +9,81 @@ interface TerminalInterface
 {
     /**
      * Get terminal details
-     *
-     * @return string
      */
-    public function getDetails();
+    public function getDetails() : string ;
 
     /**
      * Get the available width of the terminal
-     *
-     * @return int
      */
-    public function getWidth();
+    public function getWidth() : int;
 
     /**
      * Get the available height of the terminal
-     *
-     * @return int
      */
-    public function getHeight();
+    public function getHeight() : int;
 
     /**
      * Toggle canonical mode on TTY
-     *
-     * @param bool $useCanonicalMode
      */
-    public function setCanonicalMode($useCanonicalMode = true);
+    public function setCanonicalMode(bool $useCanonicalMode = true) : void;
 
     /**
      * Check if TTY is in canonical mode
-     *
-     * @return bool
      */
-    public function isCanonical();
+    public function isCanonical() : bool;
 
     /**
      * Test whether terminal is valid TTY
-     *
-     * @return bool
      */
-    public function isTTY();
+    public function isTTY() : bool;
 
     /**
      * Test whether terminal supports colour output
-     *
-     * @return bool
      */
-    public function supportsColour();
+    public function supportsColour() : bool;
 
     /**
      * Clear the terminal window
-     *
-     * @return void
      */
-    public function clear();
+    public function clear() : void;
 
     /**
      * Clear the current cursors line
-     *
-     * @return void
      */
-    public function clearLine();
+    public function clearLine() : void;
 
     /**
      * Move the cursor to the top left of the window
-     *
-     * @return void
      */
-    public function moveCursorToTop();
+    public function moveCursorToTop() : void;
 
     /**
      * Move the cursor to the start of a specific row
-     *
-     * @param int $rowNumber
      */
-    public function moveCursorToRow($rowNumber);
+    public function moveCursorToRow(int $rowNumber) : void;
 
     /**
      * Move the cursor to a specific column
-     *
-     * @param int $columnNumber
      */
-    public function moveCursorToColumn($columnNumber);
+    public function moveCursorToColumn(int $columnNumber) : void;
 
     /**
      * Clean the whole console without jumping the window
-     *
-     * @return void
      */
-    public function clean();
+    public function clean() : void;
 
     /**
      * Enable cursor display
      */
-    public function enableCursor();
+    public function enableCursor() : void;
 
     /**
      * Disable cursor display
      */
-    public function disableCursor();
+    public function disableCursor() : void;
 
     /**
      * @return string
      */
-    public function getKeyedInput();
+    public function getKeyedInput() : string;
 }

--- a/src/Terminal/TerminalInterface.php
+++ b/src/Terminal/TerminalInterface.php
@@ -3,9 +3,6 @@
 namespace PhpSchool\CliMenu\Terminal;
 
 /**
- * Interface TerminalInterface
- *
- * @package PhpSchool\CliMenu\Terminal
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
 interface TerminalInterface

--- a/src/Terminal/UnixTerminal.php
+++ b/src/Terminal/UnixTerminal.php
@@ -3,9 +3,6 @@
 namespace PhpSchool\CliMenu\Terminal;
 
 /**
- * Class UnixTerminal
- *
- * @package PhpSchool\CliMenu\Terminal
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
 class UnixTerminal implements TerminalInterface
@@ -51,30 +48,24 @@ class UnixTerminal implements TerminalInterface
 
     /**
      * Get the available width of the terminal
-     *
-     * @return int
      */
-    public function getWidth()
+    public function getWidth() : int
     {
         return $this->width ?: $this->width = (int) exec('tput cols');
     }
 
     /**
      * Get the available height of the terminal
-     *
-     * @return int
      */
-    public function getHeight()
+    public function getHeight() : int
     {
         return $this->height ?: $this->height = (int) exec('tput lines');
     }
 
     /**
      * Get terminal details
-     *
-     * @return string
      */
-    public function getDetails()
+    public function getDetails() : string
     {
         if (!$this->details) {
             $this->details = function_exists('posix_ttyname')
@@ -87,20 +78,16 @@ class UnixTerminal implements TerminalInterface
 
     /**
      * Get the original terminal configuration / mode
-     *
-     * @return string
      */
-    private function getOriginalConfiguration()
+    private function getOriginalConfiguration() : string
     {
         return $this->originalConfiguration ?: $this->originalConfiguration = exec('stty -g');
     }
 
     /**
      * Toggle canonical mode on TTY
-     *
-     * @param bool $useCanonicalMode
      */
-    public function setCanonicalMode($useCanonicalMode = true)
+    public function setCanonicalMode(bool $useCanonicalMode = true) : void
     {
         if ($useCanonicalMode) {
             exec('stty -icanon');
@@ -114,20 +101,16 @@ class UnixTerminal implements TerminalInterface
     /**
      * Check if TTY is in canonical mode
      * Assumes the terminal was never in canonical mode
-     *
-     * @return bool
      */
-    public function isCanonical()
+    public function isCanonical() : bool
     {
         return $this->isCanonical;
     }
 
     /**
      * Test whether terminal is valid TTY
-     *
-     * @return bool
      */
-    public function isTTY()
+    public function isTTY() : bool
     {
         return $this->isTTY ?: $this->isTTY = function_exists('posix_isatty') && @posix_isatty(STDOUT);
     }
@@ -135,11 +118,9 @@ class UnixTerminal implements TerminalInterface
     /**
      * Test whether terminal supports colour output
      *
-     * @return bool
-     *
      * @link https://github.com/symfony/Console/blob/master/Output/StreamOutput.php#L95-L102
      */
-    public function supportsColour()
+    public function supportsColour() : bool
     {
         if (DIRECTORY_SEPARATOR === '\\') {
             return false !== getenv('ANSICON') || 'ON' === getenv('ConEmuANSI') || 'xterm' === getenv('TERM');
@@ -148,10 +129,7 @@ class UnixTerminal implements TerminalInterface
         return $this->isTTY();
     }
 
-    /**
-     * @return string
-     */
-    public function getKeyedInput()
+    public function getKeyedInput() : string
     {
         // TODO: Move to class var?
         // TODO: up, down, enter etc in Abstract CONSTs
@@ -178,7 +156,7 @@ class UnixTerminal implements TerminalInterface
     /**
      * Clear the terminal window
      */
-    public function clear()
+    public function clear() : void
     {
         echo "\033[2J";
     }
@@ -186,7 +164,7 @@ class UnixTerminal implements TerminalInterface
     /**
      * Enable cursor
      */
-    public function enableCursor()
+    public function enableCursor() : void
     {
         echo "\033[?25h";
     }
@@ -194,7 +172,7 @@ class UnixTerminal implements TerminalInterface
     /**
      * Disable cursor
      */
-    public function disableCursor()
+    public function disableCursor() : void
     {
         echo "\033[?25l";
     }
@@ -204,37 +182,31 @@ class UnixTerminal implements TerminalInterface
      *
      * @return void
      */
-    public function moveCursorToTop()
+    public function moveCursorToTop() : void
     {
         echo "\033[H";
     }
 
     /**
      * Move the cursor to the start of a specific row
-     *
-     * @param int $rowNumber
      */
-    public function moveCursorToRow($rowNumber)
+    public function moveCursorToRow(int $rowNumber) : void
     {
         echo sprintf("\033[%d;0H", $rowNumber);
     }
 
     /**
      * Move the cursor to the start of a specific column
-     *
-     * @param int $column
      */
-    public function moveCursorToColumn($column)
+    public function moveCursorToColumn(int $column) : void
     {
         echo sprintf("\033[%dC", $column);
     }
 
     /**
      * Clear the current cursors line
-     *
-     * @return void
      */
-    public function clearLine()
+    public function clearLine() : void
     {
         echo sprintf("\033[%dD\033[K", $this->getWidth());
     }
@@ -242,7 +214,7 @@ class UnixTerminal implements TerminalInterface
     /**
      * Clean the whole console without jumping the window
      */
-    public function clean()
+    public function clean() : void
     {
         foreach (range(0, $this->getHeight()) as $rowNum) {
             $this->moveCursorToRow($rowNum);

--- a/src/Util/StringUtil.php
+++ b/src/Util/StringUtil.php
@@ -3,9 +3,6 @@
 namespace PhpSchool\CliMenu\Util;
 
 /**
- * Class StringUtil
- *
- * @package PhpSchool\CliMenu\Util
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
 class StringUtil
@@ -13,32 +10,23 @@ class StringUtil
     /**
      * Minimal multi-byte wordwrap implementation
      * which also takes break length into consideration
-     *
-     * @param string $str
-     * @param int $width
-     * @param string $break
-     * @return string
      */
-    public static function wordwrap($str, $width, $break = "\n")
+    public static function wordwrap(string $str, int $width, string $break = "\n") : string
     {
         $length = 0;
-        return implode(" ", array_map(function ($word) use (&$length, $width, $break) {
+        return implode(' ', array_map(function ($word) use (&$length, $width, $break) {
             $length += (mb_strlen($word) + 1);
 
             if ($length > $width) {
                 $length = mb_strlen($break);
-                return sprintf("%s%s", $break, $word);
+                return sprintf('%s%s', $break, $word);
             }
 
             return $word;
-        }, explode(" ", $str)));
+        }, explode(' ', $str)));
     }
 
-    /**
-     * @param string $str
-     * @return string
-     */
-    public static function stripAnsiEscapeSequence($str)
+    public static function stripAnsiEscapeSequence(string $str) : string
     {
         return preg_replace('/\x1b[^m]*m/', '', $str);
     }

--- a/test/Action/ExitActionTest.php
+++ b/test/Action/ExitActionTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ExitActionTest extends TestCase
 {
-    public function testExitActionClosesMenu()
+    public function testExitActionClosesMenu() : void
     {
         $menu = $this->getMockBuilder(CliMenu::class)
             ->disableOriginalConstructor()

--- a/test/Action/ExitActionTest.php
+++ b/test/Action/ExitActionTest.php
@@ -4,14 +4,14 @@ namespace PhpSchool\CliMenuTest\Action;
 
 use PhpSchool\CliMenu\Action\ExitAction;
 use PhpSchool\CliMenu\CliMenu;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class ExitActionTest
  * @package PhpSchool\CliMenuTest
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
-class ExitActionTest extends PHPUnit_Framework_TestCase
+class ExitActionTest extends TestCase
 {
     public function testExitActionClosesMenu()
     {

--- a/test/Action/ExitActionTest.php
+++ b/test/Action/ExitActionTest.php
@@ -7,8 +7,6 @@ use PhpSchool\CliMenu\CliMenu;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class ExitActionTest
- * @package PhpSchool\CliMenuTest
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
 class ExitActionTest extends TestCase

--- a/test/Action/GoBackActionTest.php
+++ b/test/Action/GoBackActionTest.php
@@ -4,14 +4,14 @@ namespace PhpSchool\CliMenuTest\Action;
 
 use PhpSchool\CliMenu\Action\GoBackAction;
 use PhpSchool\CliMenu\CliMenu;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class GoBackActionTest
  * @package PhpSchool\CliMenuTest
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
-class GoBackActionTest extends PHPUnit_Framework_TestCase
+class GoBackActionTest extends TestCase
 {
     public function testGoBackActionClosesMenuAndOpensParentIfMenuHasAParent()
     {

--- a/test/Action/GoBackActionTest.php
+++ b/test/Action/GoBackActionTest.php
@@ -7,8 +7,6 @@ use PhpSchool\CliMenu\CliMenu;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class GoBackActionTest
- * @package PhpSchool\CliMenuTest
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
 class GoBackActionTest extends TestCase

--- a/test/Action/GoBackActionTest.php
+++ b/test/Action/GoBackActionTest.php
@@ -11,7 +11,7 @@ use PHPUnit\Framework\TestCase;
  */
 class GoBackActionTest extends TestCase
 {
-    public function testGoBackActionClosesMenuAndOpensParentIfMenuHasAParent()
+    public function testGoBackActionClosesMenuAndOpensParentIfMenuHasAParent() : void
     {
         $parent = $this->getMockBuilder(CliMenu::class)
             ->disableOriginalConstructor()

--- a/test/CliMenuBuilderTest.php
+++ b/test/CliMenuBuilderTest.php
@@ -18,7 +18,7 @@ use RuntimeException;
  */
 class CliMenuBuilderTest extends TestCase
 {
-    public function testDefaultItems()
+    public function testDefaultItems() : void
     {
         $builder = new CliMenuBuilder;
         $menu = $builder->build();
@@ -33,7 +33,7 @@ class CliMenuBuilderTest extends TestCase
         $this->checkItems($menu, $expected);
     }
 
-    public function testModifyExitButtonText()
+    public function testModifyExitButtonText() : void
     {
         $builder = new CliMenuBuilder;
         $builder->setExitButtonText('RELEASE ME');
@@ -49,7 +49,7 @@ class CliMenuBuilderTest extends TestCase
         $this->checkItems($menu, $expected);
     }
 
-    public function testModifyStyles()
+    public function testModifyStyles() : void
     {
         $builder = new CliMenuBuilder;
         $builder->setBackgroundColour('red');
@@ -83,7 +83,7 @@ class CliMenuBuilderTest extends TestCase
         $this->checkStyleVariable($menu, 'titleSeparator', '-');
     }
 
-    public function testDisableDefaultItems()
+    public function testDisableDefaultItems() : void
     {
         $builder = new CliMenuBuilder;
         $builder->disableDefaultItems();
@@ -93,7 +93,7 @@ class CliMenuBuilderTest extends TestCase
         $this->checkVariable($menu, 'items', []);
     }
 
-    public function testSetTitle()
+    public function testSetTitle() : void
     {
         $builder = new CliMenuBuilder;
         $builder->setTitle('title');
@@ -103,7 +103,7 @@ class CliMenuBuilderTest extends TestCase
         $this->checkVariable($menu, 'title', 'title');
     }
 
-    public function testAddItem()
+    public function testAddItem() : void
     {
         $callable = function () {
         };
@@ -128,7 +128,7 @@ class CliMenuBuilderTest extends TestCase
         $this->checkItems($menu, $expected);
     }
 
-    public function testAddMultipleItems()
+    public function testAddMultipleItems() : void
     {
         $callable = function () {
         };
@@ -155,7 +155,7 @@ class CliMenuBuilderTest extends TestCase
         $this->checkItems($menu, $expected);
     }
 
-    public function testAddStaticItem()
+    public function testAddStaticItem() : void
     {
 
         $builder = new CliMenuBuilder;
@@ -173,7 +173,7 @@ class CliMenuBuilderTest extends TestCase
         $this->checkItems($menu, $expected);
     }
 
-    public function testAddLineBreakItem()
+    public function testAddLineBreakItem() : void
     {
         $builder = new CliMenuBuilder;
         $builder->disableDefaultItems();
@@ -191,7 +191,7 @@ class CliMenuBuilderTest extends TestCase
         $this->checkItems($menu, $expected);
     }
 
-    public function testAddLineBreakItemWithNumLines()
+    public function testAddLineBreakItemWithNumLines() : void
     {
         $builder = new CliMenuBuilder;
         $builder->disableDefaultItems();
@@ -209,7 +209,7 @@ class CliMenuBuilderTest extends TestCase
         $this->checkItems($menu, $expected);
     }
 
-    public function testAsciiArtWithDefaultPosition()
+    public function testAsciiArtWithDefaultPosition() : void
     {
         $builder = new CliMenuBuilder;
         $builder->disableDefaultItems();
@@ -227,7 +227,7 @@ class CliMenuBuilderTest extends TestCase
         $this->checkItems($menu, $expected);
     }
 
-    public function testAsciiArtWithSpecificPosition()
+    public function testAsciiArtWithSpecificPosition() : void
     {
         $builder = new CliMenuBuilder;
         $builder->disableDefaultItems();
@@ -245,7 +245,7 @@ class CliMenuBuilderTest extends TestCase
         $this->checkItems($menu, $expected);
     }
 
-    public function testAddAsciiArtDetectsArtThatDoesNotFitAndSkipsIt()
+    public function testAddAsciiArtDetectsArtThatDoesNotFitAndSkipsIt() : void
     {
         $builder = new CliMenuBuilder;
         $builder->setWidth(1);
@@ -257,7 +257,7 @@ class CliMenuBuilderTest extends TestCase
         }
     }
 
-    public function testEndThrowsExceptionIfNoParentBuilder()
+    public function testEndThrowsExceptionIfNoParentBuilder() : void
     {
         $builder = new CliMenuBuilder;
 
@@ -267,7 +267,7 @@ class CliMenuBuilderTest extends TestCase
         $builder->end();
     }
 
-    public function testAddSubMenu()
+    public function testAddSubMenu() : void
     {
         $builder = new CliMenuBuilder;
         $builder->disableDefaultItems();
@@ -286,7 +286,7 @@ class CliMenuBuilderTest extends TestCase
         $this->assertSame($builder, $subMenuBuilder->end());
     }
 
-    public function testSubMenuInheritsParentsStyle()
+    public function testSubMenuInheritsParentsStyle() : void
     {
         $builder = new CliMenuBuilder;
         $menu = $builder->setBackgroundColour('green')
@@ -299,7 +299,7 @@ class CliMenuBuilderTest extends TestCase
         $this->assertSame('green', $builder->getSubMenu('sub-menu')->getStyle()->getBg());
     }
 
-    public function testSubMenuDoesNotInheritsParentsStyleWhenSubMenuStyleHasAlterations()
+    public function testSubMenuDoesNotInheritsParentsStyleWhenSubMenuStyleHasAlterations() : void
     {
         $builder = new CliMenuBuilder;
         $menu = $builder->setBackgroundColour('green')
@@ -314,7 +314,7 @@ class CliMenuBuilderTest extends TestCase
         $this->assertSame('green', $menu->getStyle()->getBg());
     }
 
-    public function testGetSubMenuThrowsExceptionIfNotBuiltYet()
+    public function testGetSubMenuThrowsExceptionIfNotBuiltYet() : void
     {
         $builder = (new CliMenuBuilder)
             ->disableDefaultItems()
@@ -327,7 +327,7 @@ class CliMenuBuilderTest extends TestCase
         $builder->getSubMenu('sub-menu');
     }
 
-    public function testGetSubMenuReturnsInstanceOfBuiltSubMenu()
+    public function testGetSubMenuReturnsInstanceOfBuiltSubMenu() : void
     {
         $builder = (new CliMenuBuilder)
             ->disableDefaultItems()
@@ -342,7 +342,7 @@ class CliMenuBuilderTest extends TestCase
         $this->assertNotSame($subMenu, $menu);
     }
 
-    public function testSubMenuDefaultItems()
+    public function testSubMenuDefaultItems() : void
     {
         $builder = (new CliMenuBuilder)
             ->disableDefaultItems()
@@ -366,7 +366,7 @@ class CliMenuBuilderTest extends TestCase
         $this->checkItems($subMenu, $expected);
     }
 
-    public function testModifyExitAndGoBackTextOnSubMenu()
+    public function testModifyExitAndGoBackTextOnSubMenu() : void
     {
         $builder = (new CliMenuBuilder)
             ->disableDefaultItems()
@@ -392,7 +392,7 @@ class CliMenuBuilderTest extends TestCase
         $this->checkItems($subMenu, $expected);
     }
 
-    public function testDisableDefaultItemsDisablesExitAndGoBackOnSubMenu()
+    public function testDisableDefaultItemsDisablesExitAndGoBackOnSubMenu() : void
     {
         $builder = (new CliMenuBuilder)
             ->disableDefaultItems()
@@ -406,7 +406,7 @@ class CliMenuBuilderTest extends TestCase
         $this->checkVariable($subMenu, 'items', []);
     }
 
-    public function testThrowsExceptionWhenDisablingRootMenu()
+    public function testThrowsExceptionWhenDisablingRootMenu() : void
     {
         $this->expectException(\InvalidArgumentException::class);
         $this->expectExceptionMessage('You can\'t disable the root menu');
@@ -414,11 +414,7 @@ class CliMenuBuilderTest extends TestCase
         (new CliMenuBuilder)->disableMenu();
     }
     
-    /**
-     * @param CliMenu $menu
-     * @param array $expected
-     */
-    private function checkItems(CliMenu $menu, array $expected)
+    private function checkItems(CliMenu $menu, array $expected) : void
     {
         $actualItems = $this->readAttribute($menu, 'items');
         $this->assertCount(count($expected), $actualItems);
@@ -435,23 +431,13 @@ class CliMenuBuilderTest extends TestCase
         }
     }
     
-    /**
-     * @param CliMenu $menu
-     * @param string $property
-     * @param mixed $expected
-     */
-    private function checkVariable(CliMenu $menu, $property, $expected)
+    private function checkVariable(CliMenu $menu, string $property, $expected) : void
     {
         $actual = $this->readAttribute($menu, $property);
         $this->assertEquals($expected, $actual);
     }
 
-    /**
-     * @param CliMenu $menu
-     * @param $property
-     * @param mixed $expected
-     */
-    private function checkStyleVariable(CliMenu $menu, $property, $expected)
+    private function checkStyleVariable(CliMenu $menu, string $property, $expected) : void
     {
         $style = $this->readAttribute($menu, 'style');
         $this->assertEquals($this->readAttribute($style, $property), $expected);

--- a/test/CliMenuBuilderTest.php
+++ b/test/CliMenuBuilderTest.php
@@ -14,8 +14,6 @@ use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 /**
- * Class CliMenuBuilderTest
- * @package PhpSchool\CliMenuTest
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
 class CliMenuBuilderTest extends TestCase

--- a/test/CliMenuBuilderTest.php
+++ b/test/CliMenuBuilderTest.php
@@ -10,7 +10,7 @@ use PhpSchool\CliMenu\MenuItem\MenuMenuItem;
 use PhpSchool\CliMenu\MenuItem\SelectableItem;
 use PhpSchool\CliMenu\MenuItem\StaticItem;
 use PhpSchool\CliMenu\Terminal\TerminalInterface;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 use RuntimeException;
 
 /**
@@ -18,7 +18,7 @@ use RuntimeException;
  * @package PhpSchool\CliMenuTest
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
-class CliMenuBuilderTest extends PHPUnit_Framework_TestCase
+class CliMenuBuilderTest extends TestCase
 {
     public function testDefaultItems()
     {
@@ -263,10 +263,8 @@ class CliMenuBuilderTest extends PHPUnit_Framework_TestCase
     {
         $builder = new CliMenuBuilder;
 
-        $this->setExpectedException(
-            RuntimeException::class,
-            'No parent builder to return to'
-        );
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('No parent builder to return to');
         
         $builder->end();
     }
@@ -325,10 +323,8 @@ class CliMenuBuilderTest extends PHPUnit_Framework_TestCase
             ->addSubMenu('sub-menu')
                 ->end();
         
-        $this->setExpectedException(
-            RuntimeException::class,
-            'Menu: "sub-menu" cannot be retrieved until menu has been built'
-        );
+        $this->expectException(RuntimeException::class);
+        $this->expectExceptionMessage('Menu: "sub-menu" cannot be retrieved until menu has been built');
         
         $builder->getSubMenu('sub-menu');
     }

--- a/test/CliMenuTest.php
+++ b/test/CliMenuTest.php
@@ -9,12 +9,12 @@ use PhpSchool\CliMenu\MenuItem\SelectableItem;
 use PhpSchool\CliMenu\MenuStyle;
 use PhpSchool\CliMenu\Terminal\TerminalInterface;
 use PhpSchool\CliMenu\Terminal\UnixTerminal;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
-class CliMenuTest extends PHPUnit_Framework_TestCase
+class CliMenuTest extends TestCase
 {
     public function testGetMenuStyle()
     {

--- a/test/CliMenuTest.php
+++ b/test/CliMenuTest.php
@@ -16,7 +16,7 @@ use PHPUnit\Framework\TestCase;
  */
 class CliMenuTest extends TestCase
 {
-    public function testGetMenuStyle()
+    public function testGetMenuStyle() : void
     {
         $menu = new CliMenu('PHP School FTW', []);
         static::assertInstanceOf(MenuStyle::class, $menu->getStyle());
@@ -26,7 +26,7 @@ class CliMenuTest extends TestCase
         static::assertSame($style, $menu->getStyle());
     }
 
-    public function testReDrawThrowsExceptionIfMenuNotOpen()
+    public function testReDrawThrowsExceptionIfMenuNotOpen() : void
     {
         $menu = new CliMenu('PHP School FTW', []);
 
@@ -35,7 +35,7 @@ class CliMenuTest extends TestCase
         $menu->redraw();
     }
 
-    public function testSimpleOpenClose()
+    public function testSimpleOpenClose() : void
     {
         $terminal = $this->createMock(TerminalInterface::class);
 
@@ -63,7 +63,7 @@ class CliMenuTest extends TestCase
         $menu->open();
     }
 
-    public function testReDrawReDrawsImmediately()
+    public function testReDrawReDrawsImmediately() : void
     {
         $terminal = $this->createMock(TerminalInterface::class);
 
@@ -93,7 +93,7 @@ class CliMenuTest extends TestCase
         $menu->open();
     }
 
-    public function testGetItems()
+    public function testGetItems() : void
     {
         $item1 = new LineBreakItem();
         $item2 = new LineBreakItem();
@@ -115,7 +115,7 @@ class CliMenuTest extends TestCase
         static::assertSame([$item1, $item2], $menu->getItems());
     }
 
-    public function testRemoveItem()
+    public function testRemoveItem() : void
     {
         $item1 = new LineBreakItem();
         $item2 = new LineBreakItem();
@@ -141,7 +141,7 @@ class CliMenuTest extends TestCase
         static::assertContains($item2, $menu->getItems());
     }
 
-    public function testRemoveItemThrowsExceptionWhenItemDoesntExistInMenu()
+    public function testRemoveItemThrowsExceptionWhenItemDoesntExistInMenu() : void
     {
         $this->expectException(\InvalidArgumentException::class);
 
@@ -152,21 +152,21 @@ class CliMenuTest extends TestCase
         $menu->removeItem($item1);
     }
 
-    public function testFlashThrowsExceptionIfParameterContainsNewline()
+    public function testFlashThrowsExceptionIfParameterContainsNewline() : void
     {
         $this->expectException(\InvalidArgumentException::class);
         $menu = new CliMenu('PHP School FTW', []);
         $menu->flash("Foo\nBar");
     }
 
-    public function testConfirmThrowsExceptionIfParameterContainsNewline()
+    public function testConfirmThrowsExceptionIfParameterContainsNewline() : void
     {
         $this->expectException(\InvalidArgumentException::class);
         $menu = new CliMenu('PHP School FTW', []);
         $menu->confirm("Foo\nBar");
     }
 
-    public function testThrowsExceptionIfTerminalIsNotValidTTY()
+    public function testThrowsExceptionIfTerminalIsNotValidTTY() : void
     {
         $this->expectException(\PhpSchool\CliMenu\Exception\InvalidTerminalException::class);
 
@@ -180,13 +180,13 @@ class CliMenuTest extends TestCase
         $menu->open();
     }
 
-    public function testGetTerminal()
+    public function testGetTerminal() : void
     {
         $menu = new CliMenu('PHP School FTW', []);
         static::assertInstanceOf(UnixTerminal::class, $menu->getTerminal());
     }
 
-    public function testAddItem()
+    public function testAddItem() : void
     {
         $menu = new CliMenu('PHP School FTW', []);
 
@@ -201,19 +201,12 @@ class CliMenuTest extends TestCase
         $this->assertCount(1, $menu->getItems());
     }
 
-    /**
-     * @return string
-     */
-    private function getTestFile()
+    private function getTestFile() : string
     {
         return sprintf('%s/res/%s.txt', __DIR__, $this->getName());
     }
 
-    /**
-     * @param TerminalInterface $terminal
-     * @return MenuStyle
-     */
-    private function getStyle(TerminalInterface $terminal)
+    private function getStyle(TerminalInterface $terminal) : MenuStyle
     {
         return new MenuStyle($terminal);
     }

--- a/test/Dialogue/ConfirmTest.php
+++ b/test/Dialogue/ConfirmTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  */
 class ConfirmTest extends TestCase
 {
-    public function testConfirmWithOddLengthConfirmAndButton()
+    public function testConfirmWithOddLengthConfirmAndButton() : void
     {
         $terminal = $this->createMock(TerminalInterface::class);
 
@@ -47,7 +47,7 @@ class ConfirmTest extends TestCase
         $menu->open();
     }
 
-    public function testConfirmWithEvenLengthConfirmAndButton()
+    public function testConfirmWithEvenLengthConfirmAndButton() : void
     {
         $terminal = $this->createMock(TerminalInterface::class);
 
@@ -81,7 +81,7 @@ class ConfirmTest extends TestCase
         $menu->open();
     }
 
-    public function testConfirmWithEvenLengthConfirmAndOddLengthButton()
+    public function testConfirmWithEvenLengthConfirmAndOddLengthButton() : void
     {
         $terminal = $this->createMock(TerminalInterface::class);
 
@@ -115,7 +115,7 @@ class ConfirmTest extends TestCase
         $menu->open();
     }
 
-    public function testConfirmWithOddLengthConfirmAndEvenLengthButton()
+    public function testConfirmWithOddLengthConfirmAndEvenLengthButton() : void
     {
         $terminal = $this->createMock(TerminalInterface::class);
 
@@ -149,7 +149,7 @@ class ConfirmTest extends TestCase
         $menu->open();
     }
 
-    public function testConfirmCanOnlyBeClosedWithEnter()
+    public function testConfirmCanOnlyBeClosedWithEnter() : void
     {
         $terminal = $this->createMock(TerminalInterface::class);
 
@@ -185,19 +185,12 @@ class ConfirmTest extends TestCase
         $menu->open();
     }
 
-    /**
-     * @return string
-     */
-    private function getTestFile()
+    private function getTestFile() : string
     {
         return sprintf('%s/../res/%s.txt', __DIR__, $this->getName());
     }
 
-    /**
-     * @param TerminalInterface $terminal
-     * @return MenuStyle
-     */
-    private function getStyle(TerminalInterface $terminal)
+    private function getStyle(TerminalInterface $terminal) : MenuStyle
     {
         return new MenuStyle($terminal);
     }

--- a/test/Dialogue/ConfirmTest.php
+++ b/test/Dialogue/ConfirmTest.php
@@ -6,12 +6,12 @@ use PhpSchool\CliMenu\CliMenu;
 use PhpSchool\CliMenu\MenuItem\SelectableItem;
 use PhpSchool\CliMenu\MenuStyle;
 use PhpSchool\CliMenu\Terminal\TerminalInterface;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
-class ConfirmTest extends PHPUnit_Framework_TestCase
+class ConfirmTest extends TestCase
 {
     public function testConfirmWithOddLengthConfirmAndButton()
     {

--- a/test/Dialogue/FlashTest.php
+++ b/test/Dialogue/FlashTest.php
@@ -13,7 +13,7 @@ use PHPUnit\Framework\TestCase;
  */
 class FlashTest extends TestCase
 {
-    public function testFlashWithOddLength()
+    public function testFlashWithOddLength() : void
     {
         $terminal = $this->createMock(TerminalInterface::class);
 
@@ -47,7 +47,7 @@ class FlashTest extends TestCase
         $menu->open();
     }
 
-    public function testFlashWithEvenLength()
+    public function testFlashWithEvenLength() : void
     {
         $terminal = $this->createMock(TerminalInterface::class);
 
@@ -83,9 +83,8 @@ class FlashTest extends TestCase
 
     /**
      * @dataProvider keyProvider
-     * @param string $key
      */
-    public function testFlashCanBeClosedWithAnyKey($key)
+    public function testFlashCanBeClosedWithAnyKey(string $key) : void
     {
         $terminal = $this->createMock(TerminalInterface::class);
 
@@ -116,10 +115,7 @@ class FlashTest extends TestCase
         $menu->open();
     }
 
-    /**
-     * @return array
-     */
-    public function keyProvider()
+    public function keyProvider() : array
     {
         return [
             ['enter'],
@@ -129,19 +125,12 @@ class FlashTest extends TestCase
         ];
     }
 
-    /**
-     * @return string
-     */
-    private function getTestFile()
+    private function getTestFile() : string
     {
         return sprintf('%s/../res/%s.txt', __DIR__, $this->getName(false));
     }
 
-    /**
-     * @param TerminalInterface $terminal
-     * @return MenuStyle
-     */
-    private function getStyle(TerminalInterface $terminal)
+    private function getStyle(TerminalInterface $terminal) : MenuStyle
     {
         return new MenuStyle($terminal);
     }

--- a/test/Dialogue/FlashTest.php
+++ b/test/Dialogue/FlashTest.php
@@ -6,12 +6,12 @@ use PhpSchool\CliMenu\CliMenu;
 use PhpSchool\CliMenu\MenuItem\SelectableItem;
 use PhpSchool\CliMenu\MenuStyle;
 use PhpSchool\CliMenu\Terminal\TerminalInterface;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
-class FlashTest extends PHPUnit_Framework_TestCase
+class FlashTest extends TestCase
 {
     public function testFlashWithOddLength()
     {

--- a/test/Exception/InvalidTerminalExceptionTest.php
+++ b/test/Exception/InvalidTerminalExceptionTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
  */
 class InvalidTerminalExceptionTest extends TestCase
 {
-    public function testException()
+    public function testException() : void
     {
         $e = new InvalidTerminalException('error');
         $this->assertEquals('error', $e->getMessage());

--- a/test/Exception/InvalidTerminalExceptionTest.php
+++ b/test/Exception/InvalidTerminalExceptionTest.php
@@ -6,8 +6,6 @@ use PhpSchool\CliMenu\Exception\InvalidTerminalException;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class InvalidTerminalExceptionTest
- * @package PhpSchool\CliMenuTest\Exception
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
 class InvalidTerminalExceptionTest extends TestCase

--- a/test/Exception/InvalidTerminalExceptionTest.php
+++ b/test/Exception/InvalidTerminalExceptionTest.php
@@ -3,14 +3,14 @@
 namespace PhpSchool\CliMenuTest\Exception;
 
 use PhpSchool\CliMenu\Exception\InvalidTerminalException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class InvalidTerminalExceptionTest
  * @package PhpSchool\CliMenuTest\Exception
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
-class InvalidTerminalExceptionTest extends PHPUnit_Framework_TestCase
+class InvalidTerminalExceptionTest extends TestCase
 {
     public function testException()
     {

--- a/test/Exception/MenuNotOpenExceptionTest.php
+++ b/test/Exception/MenuNotOpenExceptionTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
  */
 class MenuNotOpenExceptionTest extends TestCase
 {
-    public function testException()
+    public function testException() : void
     {
         $e = new MenuNotOpenException('error');
         $this->assertEquals('error', $e->getMessage());

--- a/test/Exception/MenuNotOpenExceptionTest.php
+++ b/test/Exception/MenuNotOpenExceptionTest.php
@@ -3,12 +3,12 @@
 namespace PhpSchool\CliMenuTest\Exception;
 
 use PhpSchool\CliMenu\Exception\MenuNotOpenException;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
-class MenuNotOpenExceptionTest extends PHPUnit_Framework_TestCase
+class MenuNotOpenExceptionTest extends TestCase
 {
     public function testException()
     {

--- a/test/FrameTest.php
+++ b/test/FrameTest.php
@@ -10,7 +10,7 @@ use PHPUnit\Framework\TestCase;
  */
 class FrameTest extends TestCase
 {
-    public function testNewLine()
+    public function testNewLine() : void
     {
         $frame = new Frame;
         $frame->newLine();
@@ -28,7 +28,7 @@ class FrameTest extends TestCase
         $this->assertEquals(["\n", "\n"], $frame->getRows());
     }
 
-    public function testAddRows()
+    public function testAddRows() : void
     {
         $frame = new Frame;
         $frame->addRows(['one', 'two']);
@@ -37,7 +37,7 @@ class FrameTest extends TestCase
         $this->assertEquals(['one', 'two', 'three'], $frame->getRows());
     }
 
-    public function testAddRow()
+    public function testAddRow() : void
     {
         $frame = new Frame;
         $frame->addRow('one');
@@ -46,7 +46,7 @@ class FrameTest extends TestCase
         $this->assertEquals(['one', 'two'], $frame->getRows());
     }
 
-    public function testCount()
+    public function testCount() : void
     {
         $frame = new Frame;
         $frame->addRow('one');
@@ -57,7 +57,7 @@ class FrameTest extends TestCase
         $this->assertCount(2, $frame);
     }
 
-    public function testAll()
+    public function testAll() : void
     {
         $frame = new Frame;
         $frame->addRow('one');

--- a/test/FrameTest.php
+++ b/test/FrameTest.php
@@ -3,12 +3,12 @@
 namespace PhpSchool\CliMenuTest;
 
 use PhpSchool\CliMenu\Frame;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
-class FrameTest extends PHPUnit_Framework_TestCase
+class FrameTest extends TestCase
 {
     public function testNewLine()
     {

--- a/test/MenuItem/AsciiArtItemTest.php
+++ b/test/MenuItem/AsciiArtItemTest.php
@@ -8,8 +8,6 @@ use PhpSchool\CliMenu\MenuStyle;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class AsciiArtItemTest
- * @package PhpSchool\CliMenuTest\MenuItem
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
 class AsciiArtItemTest extends TestCase

--- a/test/MenuItem/AsciiArtItemTest.php
+++ b/test/MenuItem/AsciiArtItemTest.php
@@ -2,7 +2,6 @@
 
 namespace PhpSchool\CliMenuTest\MenuItem;
 
-use Assert\InvalidArgumentException;
 use PhpSchool\CliMenu\MenuItem\AsciiArtItem;
 use PhpSchool\CliMenu\MenuStyle;
 use PHPUnit\Framework\TestCase;
@@ -12,49 +11,37 @@ use PHPUnit\Framework\TestCase;
  */
 class AsciiArtItemTest extends TestCase
 {
-    public function testExceptionIsThrownIfBreakCharNotString()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        new AsciiArtItem(new \stdClass);
-    }
-
-    public function testExceptionIsThrownIfPositionNotValid()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        new AsciiArtItem('////\\\\', new \stdClass);
-    }
-
-    public function testCanSelectIsFalse()
+    public function testCanSelectIsFalse() : void
     {
         $item = new AsciiArtItem('////\\\\');
         $this->assertFalse($item->canSelect());
     }
 
-    public function testGetSelectActionReturnsNull()
+    public function testGetSelectActionReturnsNull() : void
     {
         $item = new AsciiArtItem('////\\\\');
         $this->assertNull($item->getSelectAction());
     }
 
-    public function testShowsItemExtraReturnsFalse()
+    public function testShowsItemExtraReturnsFalse() : void
     {
         $item = new AsciiArtItem('////\\\\');
         $this->assertFalse($item->showsItemExtra());
     }
 
-    public function testGetText()
+    public function testGetText() : void
     {
         $item = new AsciiArtItem('////\\\\');
         $this->assertEquals('////\\\\', $item->getText());
     }
 
-    public function testGetArtLength()
+    public function testGetArtLength() : void
     {
         $item = new AsciiArtItem("//\n//\n///");
         $this->assertEquals(3, $item->getArtLength());
     }
 
-    public function testGetRowsLeftAligned()
+    public function testGetRowsLeftAligned() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -73,7 +60,7 @@ class AsciiArtItemTest extends TestCase
         );
     }
 
-    public function testGetRowsRightAligned()
+    public function testGetRowsRightAligned() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -92,7 +79,7 @@ class AsciiArtItemTest extends TestCase
         );
     }
 
-    public function testGetRowsCenterAligned()
+    public function testGetRowsCenterAligned() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -111,7 +98,7 @@ class AsciiArtItemTest extends TestCase
         );
     }
 
-    public function testGetRowsCenterAlignedWithOddWidth()
+    public function testGetRowsCenterAlignedWithOddWidth() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -130,7 +117,7 @@ class AsciiArtItemTest extends TestCase
         );
     }
 
-    public function testHideAndShowItemExtraHasNoEffect()
+    public function testHideAndShowItemExtraHasNoEffect() : void
     {
         $item = new AsciiArtItem("//\n//", AsciiArtItem::POSITION_CENTER);
 

--- a/test/MenuItem/AsciiArtItemTest.php
+++ b/test/MenuItem/AsciiArtItemTest.php
@@ -5,14 +5,14 @@ namespace PhpSchool\CliMenuTest\MenuItem;
 use Assert\InvalidArgumentException;
 use PhpSchool\CliMenu\MenuItem\AsciiArtItem;
 use PhpSchool\CliMenu\MenuStyle;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class AsciiArtItemTest
  * @package PhpSchool\CliMenuTest\MenuItem
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
-class AsciiArtItemTest extends PHPUnit_Framework_TestCase
+class AsciiArtItemTest extends TestCase
 {
     public function testExceptionIsThrownIfBreakCharNotString()
     {

--- a/test/MenuItem/LineBreakItemTest.php
+++ b/test/MenuItem/LineBreakItemTest.php
@@ -2,7 +2,6 @@
 
 namespace PhpSchool\CliMenuTest\MenuItem;
 
-use Assert\InvalidArgumentException;
 use PhpSchool\CliMenu\MenuItem\LineBreakItem;
 use PhpSchool\CliMenu\MenuStyle;
 use PHPUnit\Framework\TestCase;
@@ -12,43 +11,31 @@ use PHPUnit\Framework\TestCase;
  */
 class LineBreakItemTest extends TestCase
 {
-    public function testExceptionIsThrownIfBreakCharNotString()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        new LineBreakItem(new \stdClass);
-    }
-
-    public function testExceptionIsThrownIfNumLinesNotInt()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        new LineBreakItem('*', new \stdClass);
-    }
-
-    public function testCanSelectIsFalse()
+    public function testCanSelectIsFalse() : void
     {
         $item = new LineBreakItem('*');
         $this->assertFalse($item->canSelect());
     }
 
-    public function testGetSelectActionReturnsNull()
+    public function testGetSelectActionReturnsNull() : void
     {
         $item = new LineBreakItem('*');
         $this->assertNull($item->getSelectAction());
     }
 
-    public function testShowsItemExtraReturnsFalse()
+    public function testShowsItemExtraReturnsFalse() : void
     {
         $item = new LineBreakItem('*');
         $this->assertFalse($item->showsItemExtra());
     }
 
-    public function testGetText()
+    public function testGetText() : void
     {
         $item = new LineBreakItem('*');
         $this->assertEquals('*', $item->getText());
     }
 
-    public function testGetRowsRepeatsCharForMenuWidth()
+    public function testGetRowsRepeatsCharForMenuWidth() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -61,7 +48,7 @@ class LineBreakItemTest extends TestCase
         $this->assertEquals(['**********'], $item->getRows($menuStyle));
     }
 
-    public function testGetRowsRepeatsCharForMenuWidthMultiLines()
+    public function testGetRowsRepeatsCharForMenuWidthMultiLines() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -74,7 +61,7 @@ class LineBreakItemTest extends TestCase
         $this->assertEquals(['**********', '**********', '**********'], $item->getRows($menuStyle));
     }
 
-    public function testGetRowsWithPhraseThatDoesNotFitInWidthEvenlyIsTrimmed()
+    public function testGetRowsWithPhraseThatDoesNotFitInWidthEvenlyIsTrimmed() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -90,7 +77,7 @@ class LineBreakItemTest extends TestCase
         $this->assertEquals(['ABCAB', 'ABCAB', 'ABCAB'], $item->getRows($menuStyle));
     }
 
-    public function testGetRowsWithMultiByteChars()
+    public function testGetRowsWithMultiByteChars() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -103,7 +90,7 @@ class LineBreakItemTest extends TestCase
         $this->assertEquals(['❅❅❅❅❅', '❅❅❅❅❅'], $item->getRows($menuStyle));
     }
 
-    public function testHideAndShowItemExtraHasNoEffect()
+    public function testHideAndShowItemExtraHasNoEffect() : void
     {
         $item = new LineBreakItem('*');
 

--- a/test/MenuItem/LineBreakItemTest.php
+++ b/test/MenuItem/LineBreakItemTest.php
@@ -5,14 +5,14 @@ namespace PhpSchool\CliMenuTest\MenuItem;
 use Assert\InvalidArgumentException;
 use PhpSchool\CliMenu\MenuItem\LineBreakItem;
 use PhpSchool\CliMenu\MenuStyle;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class LineBreakItemTest
  * @package PhpSchool\CliMenuTest\MenuItem
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
-class LineBreakItemTest extends PHPUnit_Framework_TestCase
+class LineBreakItemTest extends TestCase
 {
     public function testExceptionIsThrownIfBreakCharNotString()
     {

--- a/test/MenuItem/LineBreakItemTest.php
+++ b/test/MenuItem/LineBreakItemTest.php
@@ -8,8 +8,6 @@ use PhpSchool\CliMenu\MenuStyle;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class LineBreakItemTest
- * @package PhpSchool\CliMenuTest\MenuItem
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
 class LineBreakItemTest extends TestCase

--- a/test/MenuItem/MenuMenuItemTest.php
+++ b/test/MenuItem/MenuMenuItemTest.php
@@ -9,8 +9,6 @@ use PhpSchool\CliMenu\MenuStyle;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class MenuMenuItemTest
- * @package PhpSchool\CliMenuTest\MenuItem
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
 class MenuMenuItemTest extends TestCase

--- a/test/MenuItem/MenuMenuItemTest.php
+++ b/test/MenuItem/MenuMenuItemTest.php
@@ -6,14 +6,14 @@ use Assert\InvalidArgumentException;
 use PhpSchool\CliMenu\CliMenu;
 use PhpSchool\CliMenu\MenuItem\MenuMenuItem;
 use PhpSchool\CliMenu\MenuStyle;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class MenuMenuItemTest
  * @package PhpSchool\CliMenuTest\MenuItem
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
-class MenuMenuItemTest extends PHPUnit_Framework_TestCase
+class MenuMenuItemTest extends TestCase
 {
     public function testExceptionIsThrownIfBreakCharNotString()
     {

--- a/test/MenuItem/MenuMenuItemTest.php
+++ b/test/MenuItem/MenuMenuItemTest.php
@@ -2,7 +2,6 @@
 
 namespace PhpSchool\CliMenuTest\MenuItem;
 
-use Assert\InvalidArgumentException;
 use PhpSchool\CliMenu\CliMenu;
 use PhpSchool\CliMenu\MenuItem\MenuMenuItem;
 use PhpSchool\CliMenu\MenuStyle;
@@ -13,15 +12,7 @@ use PHPUnit\Framework\TestCase;
  */
 class MenuMenuItemTest extends TestCase
 {
-    public function testExceptionIsThrownIfBreakCharNotString()
-    {
-        $subMenu = $this->createMock(CliMenu::class);
-        
-        $this->expectException(InvalidArgumentException::class);
-        new MenuMenuItem(new \stdClass, $subMenu);
-    }
-
-    public function testCanSelectIsTrue()
+    public function testCanSelectIsTrue() : void
     {
         $subMenu = $this->createMock(CliMenu::class);
 
@@ -29,7 +20,7 @@ class MenuMenuItemTest extends TestCase
         $this->assertTrue($item->canSelect());
     }
 
-    public function testGetSelectAction()
+    public function testGetSelectAction() : void
     {
         $subMenu = $this->createMock(CliMenu::class);
 
@@ -42,7 +33,7 @@ class MenuMenuItemTest extends TestCase
         $this->assertSame('showSubMenu', $action[1]);
     }
 
-    public function testShowsItemExtra()
+    public function testShowsItemExtra() : void
     {
         $subMenu = $this->createMock(CliMenu::class);
 
@@ -50,7 +41,7 @@ class MenuMenuItemTest extends TestCase
         $this->assertFalse($item->showsItemExtra());
     }
 
-    public function testGetText()
+    public function testGetText() : void
     {
         $subMenu = $this->createMock(CliMenu::class);
 
@@ -58,7 +49,7 @@ class MenuMenuItemTest extends TestCase
         $this->assertEquals('Item', $item->getText());
     }
 
-    public function testGetRows()
+    public function testGetRows() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -73,7 +64,7 @@ class MenuMenuItemTest extends TestCase
         $this->assertEquals([' Item'], $item->getRows($menuStyle));
     }
 
-    public function testGetRowsWithUnSelectedMarker()
+    public function testGetRowsWithUnSelectedMarker() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -95,7 +86,7 @@ class MenuMenuItemTest extends TestCase
         $this->assertEquals(['* Item'], $item->getRows($menuStyle, false));
     }
 
-    public function testGetRowsWithSelectedMarker()
+    public function testGetRowsWithSelectedMarker() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -119,7 +110,7 @@ class MenuMenuItemTest extends TestCase
     }
 
 
-    public function testGetRowsWithMultipleLines()
+    public function testGetRowsWithMultipleLines() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -140,7 +131,7 @@ class MenuMenuItemTest extends TestCase
         );
     }
 
-    public function testShowSubMenu()
+    public function testShowSubMenu() : void
     {
         $mainMenu = $this->createMock(CliMenu::class);
         $subMenu = $this->createMock(CliMenu::class);
@@ -157,7 +148,7 @@ class MenuMenuItemTest extends TestCase
         $item->showSubMenu($mainMenu);
     }
 
-    public function testHideAndShowItemExtra()
+    public function testHideAndShowItemExtra() : void
     {
         $subMenu = $this->createMock(CliMenu::class);
         $item = new MenuMenuItem('Item', $subMenu);

--- a/test/MenuItem/SelectableItemTest.php
+++ b/test/MenuItem/SelectableItemTest.php
@@ -5,14 +5,14 @@ namespace PhpSchool\CliMenuTest\MenuItem;
 use Assert\InvalidArgumentException;
 use PhpSchool\CliMenu\MenuItem\SelectableItem;
 use PhpSchool\CliMenu\MenuStyle;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class SelectableItemTest
  * @package PhpSchool\CliMenuTest\MenuItem
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
-class SelectableItemTest extends PHPUnit_Framework_TestCase
+class SelectableItemTest extends TestCase
 {
     public function testExceptionIsThrownIfBreakCharNotString()
     {

--- a/test/MenuItem/SelectableItemTest.php
+++ b/test/MenuItem/SelectableItemTest.php
@@ -8,8 +8,6 @@ use PhpSchool\CliMenu\MenuStyle;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class SelectableItemTest
- * @package PhpSchool\CliMenuTest\MenuItem
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
 class SelectableItemTest extends TestCase

--- a/test/MenuItem/SelectableItemTest.php
+++ b/test/MenuItem/SelectableItemTest.php
@@ -2,7 +2,6 @@
 
 namespace PhpSchool\CliMenuTest\MenuItem;
 
-use Assert\InvalidArgumentException;
 use PhpSchool\CliMenu\MenuItem\SelectableItem;
 use PhpSchool\CliMenu\MenuStyle;
 use PHPUnit\Framework\TestCase;
@@ -12,21 +11,14 @@ use PHPUnit\Framework\TestCase;
  */
 class SelectableItemTest extends TestCase
 {
-    public function testExceptionIsThrownIfBreakCharNotString()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        new SelectableItem(new \stdClass, function () {
-        });
-    }
-
-    public function testCanSelectIsTrue()
+    public function testCanSelectIsTrue() : void
     {
         $item = new SelectableItem('Item', function () {
         });
         $this->assertTrue($item->canSelect());
     }
 
-    public function testGetSelectAction()
+    public function testGetSelectAction() : void
     {
         $callable = function () {
         };
@@ -34,7 +26,7 @@ class SelectableItemTest extends TestCase
         $this->assertSame($callable, $item->getSelectAction());
     }
 
-    public function testShowsItemExtra()
+    public function testShowsItemExtra() : void
     {
         $item = new SelectableItem('Item', function () {
         });
@@ -45,14 +37,14 @@ class SelectableItemTest extends TestCase
         $this->assertTrue($item->showsItemExtra());
     }
 
-    public function testGetText()
+    public function testGetText() : void
     {
         $item = new SelectableItem('Item', function () {
         });
         $this->assertEquals('Item', $item->getText());
     }
 
-    public function testGetRows()
+    public function testGetRows() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -68,7 +60,7 @@ class SelectableItemTest extends TestCase
         $this->assertEquals([' Item'], $item->getRows($menuStyle, true));
     }
 
-    public function testGetRowsWithUnSelectedMarker()
+    public function testGetRowsWithUnSelectedMarker() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -89,7 +81,7 @@ class SelectableItemTest extends TestCase
         $this->assertEquals(['* Item'], $item->getRows($menuStyle, false));
     }
 
-    public function testGetRowsWithSelectedMarker()
+    public function testGetRowsWithSelectedMarker() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -109,7 +101,7 @@ class SelectableItemTest extends TestCase
         $this->assertEquals(['= Item'], $item->getRows($menuStyle, true));
     }
 
-    public function testGetRowsWithItemExtra()
+    public function testGetRowsWithItemExtra() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -128,7 +120,7 @@ class SelectableItemTest extends TestCase
         $this->assertEquals([' Item       [EXTRA]'], $item->getRows($menuStyle));
     }
 
-    public function testGetRowsWithMultipleLinesWithItemExtra()
+    public function testGetRowsWithMultipleLinesWithItemExtra() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -153,7 +145,7 @@ class SelectableItemTest extends TestCase
         );
     }
 
-    public function testHideAndShowItemExtra()
+    public function testHideAndShowItemExtra() : void
     {
         $item = new SelectableItem('Item', function () {
         });

--- a/test/MenuItem/StaticItemTest.php
+++ b/test/MenuItem/StaticItemTest.php
@@ -5,13 +5,13 @@ namespace PhpSchool\CliMenuTest\MenuItem;
 use Assert\InvalidArgumentException;
 use PhpSchool\CliMenu\MenuItem\StaticItem;
 use PhpSchool\CliMenu\MenuStyle;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class StaticItemTest
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
-class StaticItemTest extends PHPUnit_Framework_TestCase
+class StaticItemTest extends TestCase
 {
     public function testExceptionIsThrownIfArgumentNotString()
     {

--- a/test/MenuItem/StaticItemTest.php
+++ b/test/MenuItem/StaticItemTest.php
@@ -2,7 +2,6 @@
 
 namespace PhpSchool\CliMenuTest\MenuItem;
 
-use Assert\InvalidArgumentException;
 use PhpSchool\CliMenu\MenuItem\StaticItem;
 use PhpSchool\CliMenu\MenuStyle;
 use PHPUnit\Framework\TestCase;
@@ -12,37 +11,31 @@ use PHPUnit\Framework\TestCase;
  */
 class StaticItemTest extends TestCase
 {
-    public function testExceptionIsThrownIfArgumentNotString()
-    {
-        $this->expectException(InvalidArgumentException::class);
-        new StaticItem(new \stdClass);
-    }
-
-    public function testCanSelectIsFalse()
+    public function testCanSelectIsFalse() : void
     {
         $item = new StaticItem('Item 1');
         $this->assertFalse($item->canSelect());
     }
 
-    public function testGetSelectActionReturnsNull()
+    public function testGetSelectActionReturnsNull() : void
     {
         $item = new StaticItem('Item 1');
         $this->assertNull($item->getSelectAction());
     }
 
-    public function testShowsItemExtraReturnsFalse()
+    public function testShowsItemExtraReturnsFalse() : void
     {
         $item = new StaticItem('Item 1');
         $this->assertFalse($item->showsItemExtra());
     }
 
-    public function testGetText()
+    public function testGetText() : void
     {
         $item = new StaticItem('Item 1');
         $this->assertEquals('Item 1', $item->getText());
     }
 
-    public function testGetRowsWithContentWhichFitsOnOneLine()
+    public function testGetRowsWithContentWhichFitsOnOneLine() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
         
@@ -59,7 +52,7 @@ class StaticItemTest extends TestCase
         );
     }
 
-    public function testGetRowsWithContentWhichDoesNotFitOnOneLineIsWrapped()
+    public function testGetRowsWithContentWhichDoesNotFitOnOneLineIsWrapped() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -76,7 +69,7 @@ class StaticItemTest extends TestCase
         );
     }
 
-    public function testHideAndShowItemExtraHasNoEffect()
+    public function testHideAndShowItemExtraHasNoEffect() : void
     {
         $item = new StaticItem('CONTENT 1 LINE');
 

--- a/test/MenuItem/StaticItemTest.php
+++ b/test/MenuItem/StaticItemTest.php
@@ -8,7 +8,6 @@ use PhpSchool\CliMenu\MenuStyle;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class StaticItemTest
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
 class StaticItemTest extends TestCase

--- a/test/MenuStyleTest.php
+++ b/test/MenuStyleTest.php
@@ -7,6 +7,7 @@ use PhpSchool\CliMenu\Exception\InvalidInstantiationException;
 use PhpSchool\CliMenu\MenuStyle;
 use PhpSchool\CliMenu\Terminal\TerminalInterface;
 use PhpSchool\CliMenu\Terminal\UnixTerminal;
+use PHPUnit\Framework\MockObject\MockObject;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -36,7 +37,7 @@ class MenuStyleTest extends TestCase
         return $style;
     }
 
-    private function getMockTerminal() : TerminalInterface
+    private function getMockTerminal() : MockObject
     {
         $terminal = $this
             ->getMockBuilder(UnixTerminal::class)

--- a/test/MenuStyleTest.php
+++ b/test/MenuStyleTest.php
@@ -6,13 +6,13 @@ use PhpSchool\CliMenu\CliMenuBuilder;
 use PhpSchool\CliMenu\Exception\InvalidInstantiationException;
 use PhpSchool\CliMenu\MenuStyle;
 use PhpSchool\CliMenu\Terminal\UnixTerminal;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class MenuStyleTest
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
-class MenuStyleTest extends PHPUnit_Framework_TestCase
+class MenuStyleTest extends TestCase
 {
     /**
      * @return MenuStyle

--- a/test/MenuStyleTest.php
+++ b/test/MenuStyleTest.php
@@ -9,7 +9,6 @@ use PhpSchool\CliMenu\Terminal\UnixTerminal;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class MenuStyleTest
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
 class MenuStyleTest extends TestCase

--- a/test/MenuStyleTest.php
+++ b/test/MenuStyleTest.php
@@ -5,6 +5,7 @@ namespace PhpSchool\CliMenuTest;
 use PhpSchool\CliMenu\CliMenuBuilder;
 use PhpSchool\CliMenu\Exception\InvalidInstantiationException;
 use PhpSchool\CliMenu\MenuStyle;
+use PhpSchool\CliMenu\Terminal\TerminalInterface;
 use PhpSchool\CliMenu\Terminal\UnixTerminal;
 use PHPUnit\Framework\TestCase;
 
@@ -13,10 +14,7 @@ use PHPUnit\Framework\TestCase;
  */
 class MenuStyleTest extends TestCase
 {
-    /**
-     * @return MenuStyle
-     */
-    private function getMenuStyle()
+    private function getMenuStyle() : MenuStyle
     {
         // Use the CliMenuBuilder & reflection to get the style Obj
         $builder = new CliMenuBuilder();
@@ -38,7 +36,7 @@ class MenuStyleTest extends TestCase
         return $style;
     }
 
-    private function getMockTerminal()
+    private function getMockTerminal() : TerminalInterface
     {
         $terminal = $this
             ->getMockBuilder(UnixTerminal::class)
@@ -54,7 +52,7 @@ class MenuStyleTest extends TestCase
         return $terminal;
     }
 
-    public function testMenuStyleCanBeInstantiatedByCliMenuBuilder()
+    public function testMenuStyleCanBeInstantiatedByCliMenuBuilder() : void
     {
         $builder = new CliMenuBuilder();
         $menu    = $builder->build();
@@ -69,7 +67,7 @@ class MenuStyleTest extends TestCase
         static::assertSame(MenuStyle::class, get_class($style));
     }
 
-    public function testAvailableColours()
+    public function testAvailableColours() : void
     {
         static::assertSame([
             'black',
@@ -84,27 +82,27 @@ class MenuStyleTest extends TestCase
         ], MenuStyle::getAvailableColours());
     }
 
-    public function testGetSelectedSetCode()
+    public function testGetSelectedSetCode() : void
     {
         static::assertSame("\e[47;34m", $this->getMenuStyle()->getSelectedSetCode());
     }
 
-    public function testGetSelectedUnsetCode()
+    public function testGetSelectedUnsetCode() : void
     {
         static::assertSame("\e[49;39m", $this->getMenuStyle()->getSelectedUnsetCode());
     }
 
-    public function testGetUnselectedSetCode()
+    public function testGetUnselectedSetCode() : void
     {
         static::assertSame("\e[44;37m", $this->getMenuStyle()->getUnselectedSetCode());
     }
 
-    public function testGetUnselectedUnsetCode()
+    public function testGetUnselectedUnsetCode() : void
     {
         static::assertSame("\e[49;39m", $this->getMenuStyle()->getUnselectedUnsetCode());
     }
 
-    public function testGetterAndSetters()
+    public function testGetterAndSetters() : void
     {
         $style = $this->getMenuStyle();
 
@@ -142,7 +140,7 @@ class MenuStyleTest extends TestCase
         static::assertSame(10, $style->getPadding());
     }
 
-    public function testGetMarkerReturnsTheCorrectMarkers()
+    public function testGetMarkerReturnsTheCorrectMarkers() : void
     {
         $style = $this->getMenuStyle();
 
@@ -153,7 +151,7 @@ class MenuStyleTest extends TestCase
         static::assertSame('x', $style->getMarker(false));
     }
 
-    public function testWidthCalculation()
+    public function testWidthCalculation() : void
     {
         $style = $this->getMenuStyle();
 
@@ -164,7 +162,7 @@ class MenuStyleTest extends TestCase
         static::assertSame(280, $style->getContentWidth());
     }
 
-    public function testRightHandPaddingCalculation()
+    public function testRightHandPaddingCalculation() : void
     {
         $style = $this->getMenuStyle();
 

--- a/test/Util/StringUtilTest.php
+++ b/test/Util/StringUtilTest.php
@@ -6,8 +6,6 @@ use PhpSchool\CliMenu\Util\StringUtil;
 use PHPUnit\Framework\TestCase;
 
 /**
- * Class StringUtilTest
- * @package PhpSchool\CliMenuTest\MenuItem
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
 class StringUtilTest extends TestCase

--- a/test/Util/StringUtilTest.php
+++ b/test/Util/StringUtilTest.php
@@ -12,7 +12,7 @@ class StringUtilTest extends TestCase
 {
     protected $dummyText;
 
-    public function testItWrapsAsExpectedTo80Length()
+    public function testItWrapsAsExpectedTo80Length() : void
     {
 
         $result = StringUtil::wordwrap($this->dummyText, 80);
@@ -26,7 +26,7 @@ class StringUtilTest extends TestCase
         $this->assertEquals($result, $expected);
     }
 
-    public function testItWrapsAsExpectedTo60Length()
+    public function testItWrapsAsExpectedTo60Length() : void
     {
 
         $result = StringUtil::wordwrap($this->dummyText, 60);
@@ -42,7 +42,7 @@ class StringUtilTest extends TestCase
         $this->assertEquals($result, $expected);
     }
 
-    public function testItCanUseACustomBreakCharacter()
+    public function testItCanUseACustomBreakCharacter() : void
     {
 
         $result = StringUtil::wordwrap($this->dummyText, 60, 'H');
@@ -58,7 +58,7 @@ class StringUtilTest extends TestCase
         $this->assertEquals($result, $expected);
     }
 
-    public function testItCanStripAnsiEscapeSequence()
+    public function testItCanStripAnsiEscapeSequence() : void
     {
         $result = StringUtil::stripAnsiEscapeSequence("\x1b[7mfoo\x1b[0m");
         $this->assertEquals('foo', $result);
@@ -70,9 +70,9 @@ class StringUtilTest extends TestCase
         $this->assertEquals('foobarbaz!!!', $result);
     }
 
-    protected function setup()
+    protected function setup() : void
     {
-        parent::setup();
+        parent::setUp();
 
         $this->dummyText = 'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor ' .
             'incididunt ut labore et dolore magna aliqua. Ut enim ad minim veniam, quis nostrud ' .

--- a/test/Util/StringUtilTest.php
+++ b/test/Util/StringUtilTest.php
@@ -3,14 +3,14 @@
 namespace PhpSchool\CliMenuTest\Util;
 
 use PhpSchool\CliMenu\Util\StringUtil;
-use PHPUnit_Framework_TestCase;
+use PHPUnit\Framework\TestCase;
 
 /**
  * Class StringUtilTest
  * @package PhpSchool\CliMenuTest\MenuItem
  * @author Aydin Hassan <aydin@hotmail.co.uk>
  */
-class StringUtilTest extends PHPUnit_Framework_TestCase
+class StringUtilTest extends TestCase
 {
     protected $dummyText;
 


### PR DESCRIPTION
* Minimum PHP version now `7.1`
* Updated dependencies
* Remove useless `@package` + `Class` doc blocks
* Add type hints everywhere and removed useless assertions + remove doc block hints
* Added phpstan to build