### PR TITLE
Refactor IO

### DIFF
--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -254,7 +254,7 @@ class CliMenu
         $frame->newLine(2);
 
         foreach ($frame->getRows() as $row) {
-            echo $row;
+            $this->terminal->getOutput()->write($row);
         }
 
         $this->currentFrame = $frame;

--- a/src/Dialogue/Dialogue.php
+++ b/src/Dialogue/Dialogue.php
@@ -101,7 +101,7 @@ abstract class Dialogue
     protected function write(string $text, int $column = null) : void
     {
         $this->terminal->moveCursorToColumn($column ?: $this->x);
-        echo $text;
+        $this->terminal->getOutput()->write($text);
     }
 
     public function getStyle() : MenuStyle

--- a/src/IO/BufferedOutput.php
+++ b/src/IO/BufferedOutput.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace PhpSchool\CliMenu\IO;
+
+/**
+ * @author Aydin Hassan <aydin@hotmail.co.uk>
+ */
+class BufferedOutput implements OutputStream
+{
+    private $buffer = '';
+
+    public function write(string $buffer): void
+    {
+        $this->buffer .= $buffer;
+    }
+
+    public function fetch(bool $clean = true) : string
+    {
+        $buffer = $this->buffer;
+
+        if ($clean) {
+            $this->buffer = '';
+        }
+
+        return $buffer;
+    }
+
+    public function __toString() : string
+    {
+        return $this->fetch();
+    }
+}

--- a/src/IO/InputStream.php
+++ b/src/IO/InputStream.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace PhpSchool\CliMenu\IO;
+
+/**
+ * @author Aydin Hassan <aydin@hotmail.co.uk>
+ */
+interface InputStream
+{
+    /**
+     * Callback should be called with the number of bytes requested
+     * when ready.
+     */
+    public function read(int $numBytes, callable $callback) : void;
+}

--- a/src/IO/OutputStream.php
+++ b/src/IO/OutputStream.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PhpSchool\CliMenu\IO;
+
+/**
+ * @author Aydin Hassan <aydin@hotmail.co.uk>
+ */
+interface OutputStream
+{
+    public function write(string $buffer) : void;
+}

--- a/src/IO/ResourceInputStream.php
+++ b/src/IO/ResourceInputStream.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace PhpSchool\CliMenu\IO;
+
+use function is_resource;
+use function get_resource_type;
+use function stream_get_meta_data;
+use function strpos;
+
+/**
+ * @author Aydin Hassan <aydin@hotmail.co.uk>
+ */
+class ResourceInputStream implements InputStream
+{
+    /**
+     * @var resource
+     */
+    private $stream;
+
+    public function __construct($stream = null)
+    {
+        if ($stream === null) {
+            $stream = STDIN;
+        }
+
+        if (!is_resource($stream) || get_resource_type($stream) !== 'stream') {
+            throw new \InvalidArgumentException('Expected a valid stream');
+        }
+
+        $meta = stream_get_meta_data($stream);
+        if (strpos($meta['mode'], 'r') === false && strpos($meta['mode'], '+') === false) {
+            throw new \InvalidArgumentException('Expected a readable stream');
+        }
+
+        $this->stream = $stream;
+    }
+
+    public function read(int $numBytes, callable $callback) : void
+    {
+        $buffer = fread($this->stream, $numBytes);
+        $callback($buffer);
+    }
+}

--- a/src/IO/ResourceOutputStream.php
+++ b/src/IO/ResourceOutputStream.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace PhpSchool\CliMenu\IO;
+
+use function is_resource;
+use function get_resource_type;
+use function stream_get_meta_data;
+use function strpos;
+
+/**
+ * @author Aydin Hassan <aydin@hotmail.co.uk>
+ */
+class ResourceOutputStream implements OutputStream
+{
+    /**
+     * @var resource
+     */
+    private $stream;
+
+    public function __construct($stream = null)
+    {
+        if ($stream === null) {
+            $stream = STDOUT;
+        }
+
+        if (!is_resource($stream) || get_resource_type($stream) !== 'stream') {
+            throw new \InvalidArgumentException('Expected a valid stream');
+        }
+
+        $meta = stream_get_meta_data($stream);
+        if (strpos($meta['mode'], 'r') !== false && strpos($meta['mode'], '+') === false) {
+            throw new \InvalidArgumentException('Expected a writable stream');
+        }
+
+        $this->stream = $stream;
+    }
+
+    public function write(string $buffer): void
+    {
+        fwrite($this->stream, $buffer);
+    }
+}

--- a/src/Terminal/TerminalFactory.php
+++ b/src/Terminal/TerminalFactory.php
@@ -2,6 +2,9 @@
 
 namespace PhpSchool\CliMenu\Terminal;
 
+use PhpSchool\CliMenu\IO\ResourceInputStream;
+use PhpSchool\CliMenu\IO\ResourceOutputStream;
+
 /**
  * @author Michael Woodward <mikeymike.mw@gmail.com>
  */
@@ -9,6 +12,6 @@ class TerminalFactory
 {
     public static function fromSystem() : TerminalInterface
     {
-        return new UnixTerminal();
+        return new UnixTerminal(new ResourceInputStream, new ResourceOutputStream);
     }
 }

--- a/src/Terminal/TerminalInterface.php
+++ b/src/Terminal/TerminalInterface.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace PhpSchool\CliMenu\Terminal;
+use PhpSchool\CliMenu\IO\OutputStream;
 
 /**
  * @author Michael Woodward <mikeymike.mw@gmail.com>
@@ -85,5 +86,10 @@ interface TerminalInterface
     /**
      * @return string
      */
-    public function getKeyedInput() : string;
+    public function getKeyedInput(array $map = []) : ?string;
+
+    /**
+     * Get the output stream
+     */
+    public function getOutput() : OutputStream;
 }

--- a/src/Terminal/TerminalInterface.php
+++ b/src/Terminal/TerminalInterface.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace PhpSchool\CliMenu\Terminal;
+
 use PhpSchool\CliMenu\IO\OutputStream;
 
 /**

--- a/src/Terminal/UnixTerminal.php
+++ b/src/Terminal/UnixTerminal.php
@@ -1,6 +1,7 @@
 <?php
 
 namespace PhpSchool\CliMenu\Terminal;
+
 use PhpSchool\CliMenu\IO\InputStream;
 use PhpSchool\CliMenu\IO\OutputStream;
 

--- a/test/Dialogue/ConfirmTest.php
+++ b/test/Dialogue/ConfirmTest.php
@@ -3,6 +3,7 @@
 namespace PhpSchool\CliMenuTest\Dialogue;
 
 use PhpSchool\CliMenu\CliMenu;
+use PhpSchool\CliMenu\IO\BufferedOutput;
 use PhpSchool\CliMenu\MenuItem\SelectableItem;
 use PhpSchool\CliMenu\MenuStyle;
 use PhpSchool\CliMenu\Terminal\TerminalInterface;
@@ -13,26 +14,43 @@ use PHPUnit\Framework\TestCase;
  */
 class ConfirmTest extends TestCase
 {
-    public function testConfirmWithOddLengthConfirmAndButton() : void
-    {
-        $terminal = $this->createMock(TerminalInterface::class);
+    /**
+     * @var TerminalInterface
+     */
+    private $terminal;
 
-        $terminal->expects($this->any())
+    /**
+     * @var BufferedOutput
+     */
+    private $output;
+
+    public function setUp()
+    {
+        $this->output = new BufferedOutput;
+        $this->terminal = $this->createMock(TerminalInterface::class);
+        $this->terminal->expects($this->any())
+            ->method('getOutput')
+            ->willReturn($this->output);
+
+        $this->terminal->expects($this->any())
             ->method('isTTY')
             ->willReturn(true);
 
-        $terminal
+        $this->terminal->expects($this->any())
+            ->method('getWidth')
+            ->willReturn(50);
+    }
+
+    public function testConfirmWithOddLengthConfirmAndButton() : void
+    {
+        $this->terminal
             ->method('getKeyedInput')
             ->will($this->onConsecutiveCalls(
                 'enter',
                 'enter'
             ));
 
-        $terminal->expects($this->any())
-            ->method('getWidth')
-            ->willReturn(50);
-
-        $style = $this->getStyle($terminal);
+        $style = $this->getStyle($this->terminal);
 
         $item = new SelectableItem('Item 1', function (CliMenu $menu) {
             $menu->confirm('PHP School FTW!')
@@ -41,32 +59,22 @@ class ConfirmTest extends TestCase
             $menu->close();
         });
 
-        $this->expectOutputString(file_get_contents($this->getTestFile()));
-
-        $menu = new CliMenu('PHP School FTW', [$item], $terminal, $style);
+        $menu = new CliMenu('PHP School FTW', [$item], $this->terminal, $style);
         $menu->open();
+
+        static::assertEquals($this->output->fetch(), file_get_contents($this->getTestFile()));
     }
 
     public function testConfirmWithEvenLengthConfirmAndButton() : void
     {
-        $terminal = $this->createMock(TerminalInterface::class);
-
-        $terminal->expects($this->any())
-            ->method('isTTY')
-            ->willReturn(true);
-
-        $terminal
+        $this->terminal
             ->method('getKeyedInput')
             ->will($this->onConsecutiveCalls(
                 'enter',
                 'enter'
             ));
 
-        $terminal->expects($this->any())
-            ->method('getWidth')
-            ->willReturn(50);
-
-        $style = $this->getStyle($terminal);
+        $style = $this->getStyle($this->terminal);
 
         $item = new SelectableItem('Item 1', function (CliMenu $menu) {
             $menu->confirm('PHP School FTW')
@@ -75,32 +83,22 @@ class ConfirmTest extends TestCase
             $menu->close();
         });
 
-        $this->expectOutputString(file_get_contents($this->getTestFile()));
-
-        $menu = new CliMenu('PHP School FTW', [$item], $terminal, $style);
+        $menu = new CliMenu('PHP School FTW', [$item], $this->terminal, $style);
         $menu->open();
+
+        static::assertEquals($this->output->fetch(), file_get_contents($this->getTestFile()));
     }
 
     public function testConfirmWithEvenLengthConfirmAndOddLengthButton() : void
     {
-        $terminal = $this->createMock(TerminalInterface::class);
-
-        $terminal->expects($this->any())
-            ->method('isTTY')
-            ->willReturn(true);
-
-        $terminal
+        $this->terminal
             ->method('getKeyedInput')
             ->will($this->onConsecutiveCalls(
                 'enter',
                 'enter'
             ));
 
-        $terminal->expects($this->any())
-            ->method('getWidth')
-            ->willReturn(50);
-
-        $style = $this->getStyle($terminal);
+        $style = $this->getStyle($this->terminal);
 
         $item = new SelectableItem('Item 1', function (CliMenu $menu) {
             $menu->confirm('PHP School FTW')
@@ -109,32 +107,22 @@ class ConfirmTest extends TestCase
             $menu->close();
         });
 
-        $this->expectOutputString(file_get_contents($this->getTestFile()));
-
-        $menu = new CliMenu('PHP School FTW', [$item], $terminal, $style);
+        $menu = new CliMenu('PHP School FTW', [$item], $this->terminal, $style);
         $menu->open();
+
+        static::assertEquals($this->output->fetch(), file_get_contents($this->getTestFile()));
     }
 
     public function testConfirmWithOddLengthConfirmAndEvenLengthButton() : void
     {
-        $terminal = $this->createMock(TerminalInterface::class);
-
-        $terminal->expects($this->any())
-            ->method('isTTY')
-            ->willReturn(true);
-
-        $terminal
+        $this->terminal
             ->method('getKeyedInput')
             ->will($this->onConsecutiveCalls(
                 'enter',
                 'enter'
             ));
 
-        $terminal->expects($this->any())
-            ->method('getWidth')
-            ->willReturn(50);
-
-        $style = $this->getStyle($terminal);
+        $style = $this->getStyle($this->terminal);
 
         $item = new SelectableItem('Item 1', function (CliMenu $menu) {
             $menu->confirm('PHP School FTW!')
@@ -143,21 +131,15 @@ class ConfirmTest extends TestCase
             $menu->close();
         });
 
-        $this->expectOutputString(file_get_contents($this->getTestFile()));
-
-        $menu = new CliMenu('PHP School FTW', [$item], $terminal, $style);
+        $menu = new CliMenu('PHP School FTW', [$item], $this->terminal, $style);
         $menu->open();
+
+        static::assertEquals($this->output->fetch(), file_get_contents($this->getTestFile()));
     }
 
     public function testConfirmCanOnlyBeClosedWithEnter() : void
     {
-        $terminal = $this->createMock(TerminalInterface::class);
-
-        $terminal->expects($this->any())
-            ->method('isTTY')
-            ->willReturn(true);
-
-        $terminal
+        $this->terminal
             ->method('getKeyedInput')
             ->will($this->onConsecutiveCalls(
                 'enter',
@@ -166,11 +148,7 @@ class ConfirmTest extends TestCase
                 'enter'
             ));
 
-        $terminal->expects($this->any())
-            ->method('getWidth')
-            ->willReturn(50);
-
-        $style = $this->getStyle($terminal);
+        $style = $this->getStyle($this->terminal);
 
         $item = new SelectableItem('Item 1', function (CliMenu $menu) {
             $menu->confirm('PHP School FTW!')
@@ -179,10 +157,10 @@ class ConfirmTest extends TestCase
             $menu->close();
         });
 
-        $this->expectOutputString(file_get_contents($this->getTestFile()));
-
-        $menu = new CliMenu('PHP School FTW', [$item], $terminal, $style);
+        $menu = new CliMenu('PHP School FTW', [$item], $this->terminal, $style);
         $menu->open();
+
+        static::assertEquals($this->output->fetch(), file_get_contents($this->getTestFile()));
     }
 
     private function getTestFile() : string

--- a/test/Dialogue/FlashTest.php
+++ b/test/Dialogue/FlashTest.php
@@ -3,6 +3,7 @@
 namespace PhpSchool\CliMenuTest\Dialogue;
 
 use PhpSchool\CliMenu\CliMenu;
+use PhpSchool\CliMenu\IO\BufferedOutput;
 use PhpSchool\CliMenu\MenuItem\SelectableItem;
 use PhpSchool\CliMenu\MenuStyle;
 use PhpSchool\CliMenu\Terminal\TerminalInterface;
@@ -13,26 +14,43 @@ use PHPUnit\Framework\TestCase;
  */
 class FlashTest extends TestCase
 {
-    public function testFlashWithOddLength() : void
-    {
-        $terminal = $this->createMock(TerminalInterface::class);
+    /**
+     * @var TerminalInterface
+     */
+    private $terminal;
 
-        $terminal->expects($this->any())
+    /**
+     * @var BufferedOutput
+     */
+    private $output;
+
+    public function setUp()
+    {
+        $this->output = new BufferedOutput;
+        $this->terminal = $this->createMock(TerminalInterface::class);
+        $this->terminal->expects($this->any())
+            ->method('getOutput')
+            ->willReturn($this->output);
+
+        $this->terminal->expects($this->any())
             ->method('isTTY')
             ->willReturn(true);
 
-        $terminal
+        $this->terminal->expects($this->any())
+            ->method('getWidth')
+            ->willReturn(50);
+    }
+
+    public function testFlashWithOddLength() : void
+    {
+        $this->terminal
             ->method('getKeyedInput')
             ->will($this->onConsecutiveCalls(
                 'enter',
                 'enter'
             ));
 
-        $terminal->expects($this->any())
-            ->method('getWidth')
-            ->willReturn(50);
-
-        $style = $this->getStyle($terminal);
+        $style = $this->getStyle($this->terminal);
 
         $item = new SelectableItem('Item 1', function (CliMenu $menu) {
             $menu->flash('PHP School FTW!')
@@ -41,32 +59,22 @@ class FlashTest extends TestCase
             $menu->close();
         });
 
-        $this->expectOutputString(file_get_contents($this->getTestFile()));
-
-        $menu = new CliMenu('PHP School FTW', [$item], $terminal, $style);
+        $menu = new CliMenu('PHP School FTW', [$item], $this->terminal, $style);
         $menu->open();
+
+        static::assertEquals($this->output->fetch(), file_get_contents($this->getTestFile()));
     }
 
     public function testFlashWithEvenLength() : void
     {
-        $terminal = $this->createMock(TerminalInterface::class);
-
-        $terminal->expects($this->any())
-            ->method('isTTY')
-            ->willReturn(true);
-
-        $terminal
+        $this->terminal
             ->method('getKeyedInput')
             ->will($this->onConsecutiveCalls(
                 'enter',
                 'enter'
             ));
 
-        $terminal->expects($this->any())
-            ->method('getWidth')
-            ->willReturn(50);
-
-        $style = $this->getStyle($terminal);
+        $style = $this->getStyle($this->terminal);
 
         $item = new SelectableItem('Item 1', function (CliMenu $menu) {
             $menu->flash('PHP School FTW')
@@ -75,10 +83,10 @@ class FlashTest extends TestCase
             $menu->close();
         });
 
-        $this->expectOutputString(file_get_contents($this->getTestFile()));
-
-        $menu = new CliMenu('PHP School FTW', [$item], $terminal, $style);
+        $menu = new CliMenu('PHP School FTW', [$item], $this->terminal, $style);
         $menu->open();
+
+        static::assertEquals($this->output->fetch(), file_get_contents($this->getTestFile()));
     }
 
     /**
@@ -86,21 +94,11 @@ class FlashTest extends TestCase
      */
     public function testFlashCanBeClosedWithAnyKey(string $key) : void
     {
-        $terminal = $this->createMock(TerminalInterface::class);
-
-        $terminal->expects($this->any())
-            ->method('isTTY')
-            ->willReturn(true);
-
-        $terminal
+        $this->terminal
             ->method('getKeyedInput')
             ->will($this->onConsecutiveCalls('enter', $key));
 
-        $terminal->expects($this->any())
-            ->method('getWidth')
-            ->willReturn(50);
-
-        $style = $this->getStyle($terminal);
+        $style = $this->getStyle($this->terminal);
 
         $item = new SelectableItem('Item 1', function (CliMenu $menu) {
             $menu->flash('PHP School FTW!')
@@ -109,10 +107,10 @@ class FlashTest extends TestCase
             $menu->close();
         });
 
-        $this->expectOutputString(file_get_contents($this->getTestFile()));
-
-        $menu = new CliMenu('PHP School FTW', [$item], $terminal, $style);
+        $menu = new CliMenu('PHP School FTW', [$item], $this->terminal, $style);
         $menu->open();
+
+        static::assertEquals($this->output->fetch(), file_get_contents($this->getTestFile()));
     }
 
     public function keyProvider() : array

--- a/test/IO/BufferedOutputTest.php
+++ b/test/IO/BufferedOutputTest.php
@@ -1,0 +1,50 @@
+<?php
+
+namespace PhpSchool\CliMenuTest\IO;
+
+use PhpSchool\CliMenu\IO\BufferedOutput;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Aydin Hassan <aydin@hotmail.co.uk>
+ */
+class BufferedOutputTest extends TestCase
+{
+    public function testFetch() : void
+    {
+        $output = new BufferedOutput;
+        $output->write('one');
+
+        static::assertEquals('one', $output->fetch());
+    }
+
+    public function testFetchWithMultipleWrites() : void
+    {
+        $output = new BufferedOutput;
+        $output->write('one');
+        $output->write('two');
+
+        static::assertEquals('onetwo', $output->fetch());
+    }
+
+    public function testFetchCleansBufferByDefault() : void
+    {
+        $output = new BufferedOutput;
+        $output->write('one');
+
+        static::assertEquals('one', $output->fetch());
+        static::assertEquals('', $output->fetch());
+    }
+
+    public function testFetchWithoutCleaning() : void
+    {
+        $output = new BufferedOutput;
+        $output->write('one');
+
+        static::assertEquals('one', $output->fetch(false));
+
+        $output->write('two');
+
+        static::assertEquals('onetwo', $output->fetch(false));
+    }
+}

--- a/test/IO/ResourceInputStreamTest.php
+++ b/test/IO/ResourceInputStreamTest.php
@@ -26,7 +26,7 @@ class ResourceInputStreamTest extends TestCase
 
     public function testRead() : void
     {
-        $stream = fopen('php://memory','r+');
+        $stream = fopen('php://memory', 'r+');
         fwrite($stream, '1234');
         rewind($stream);
 

--- a/test/IO/ResourceInputStreamTest.php
+++ b/test/IO/ResourceInputStreamTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace PhpSchool\CliMenuTest\IO;
+
+use PhpSchool\CliMenu\IO\ResourceInputStream;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Aydin Hassan <aydin@hotmail.co.uk>
+ */
+class ResourceInputStreamTest extends TestCase
+{
+    public function testNonStream() : void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected a valid stream');
+        new ResourceInputStream(42);
+    }
+
+    public function testNotReadable() : void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected a readable stream');
+        new ResourceInputStream(\STDOUT);
+    }
+
+    public function testRead() : void
+    {
+        $stream = fopen('php://memory','r+');
+        fwrite($stream, '1234');
+        rewind($stream);
+
+        $inputStream = new ResourceInputStream($stream);
+
+        $input = '';
+        $inputStream->read(4, function ($buffer) use (&$input) {
+            $input .= $buffer;
+        });
+
+        static::assertSame('1234', $input);
+
+        fclose($stream);
+    }
+}

--- a/test/IO/ResourceOutputStreamTest.php
+++ b/test/IO/ResourceOutputStreamTest.php
@@ -26,7 +26,7 @@ class ResourceOutputStreamTest extends TestCase
 
     public function testWrite() : void
     {
-        $stream = fopen('php://memory','r+');
+        $stream = fopen('php://memory', 'r+');
         $outputStream = new ResourceOutputStream($stream);
         $outputStream->write('123456789');
 

--- a/test/IO/ResourceOutputStreamTest.php
+++ b/test/IO/ResourceOutputStreamTest.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace PhpSchool\CliMenuTest\IO;
+
+use PhpSchool\CliMenu\IO\ResourceOutputStream;
+use PHPUnit\Framework\TestCase;
+
+/**
+ * @author Aydin Hassan <aydin@hotmail.co.uk>
+ */
+class ResourceOutputStreamTest extends TestCase
+{
+    public function testNonStream() : void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected a valid stream');
+        new ResourceOutputStream(42);
+    }
+
+    public function testNotWritable() : void
+    {
+        $this->expectException(\InvalidArgumentException::class);
+        $this->expectExceptionMessage('Expected a writable stream');
+        new ResourceOutputStream(\STDIN);
+    }
+
+    public function testWrite() : void
+    {
+        $stream = fopen('php://memory','r+');
+        $outputStream = new ResourceOutputStream($stream);
+        $outputStream->write('123456789');
+
+        rewind($stream);
+        static::assertEquals('123456789', stream_get_contents($stream));
+    }
+}


### PR DESCRIPTION
Refactor the input + output to their own stream based handlers - allows to use with virtual terminals and in non-blocking apps. Inspired by https://www.reddit.com/r/PHP/comments/59qpk8/phpschoolclimenu_200/d9asoli/ and code from https://github.com/amphp/byte-stream. 

It improves the tests by allowing phpunit output buffering to replaced by our own implementation. This is also helping me with the input tests a lot.

Only thing I'm not sure of is whether the terminal object should be the point of writing eg `$terminal->getOutput()->write('string');` Also not sure if I care - we can change it later if we want, I am happy to hear suggestions though. 