### PR TITLE
Refresh only needed rows

### DIFF
--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -305,8 +305,6 @@ class CliMenu
             );
         }, $rows);
 
-        $item->setNumberOfRows(count($rows));
-
         return array($rows, $item);
     }
 

--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -168,9 +168,9 @@ class CliMenu
                     $previousItem = $this->getSelectedItem();
                     $this->moveSelection($input);
                     $newItem = $this->getSelectedItem();
-					if ($previousItem !== $newItem) {
-						$this->draw($previousItem, $newItem);
-					}
+                    if ($previousItem !== $newItem) {
+                        $this->draw($previousItem, $newItem);
+                    }
                     break;
                 case 'enter':
                     $this->executeCurrentItem();
@@ -253,30 +253,30 @@ class CliMenu
 
         $frame->addRows($this->drawMenuItem(new LineBreakItem()));
 
-		$frame->newLine(2);
+        $frame->newLine(2);
 
-		if ($previousItem && $newItem) {
+        if ($previousItem && $newItem) {
 
-			$rows = $frame->getRows();
+            $rows = $frame->getRows();
 
-			$this->terminal->moveCursorToTop();
-			$this->terminal->moveCursorDown($previousItem->getStartRowNumber());
-			echo rtrim($rows[$previousItem->getStartRowNumber()], "\n\r");
+            $this->terminal->moveCursorToTop();
+            $this->terminal->moveCursorDown($previousItem->getStartRowNumber());
+            echo rtrim($rows[$previousItem->getStartRowNumber()], "\n\r");
 
-			$this->terminal->moveCursorToTop();
-			$this->terminal->moveCursorDown($newItem->getStartRowNumber());
-			echo rtrim($rows[$newItem->getStartRowNumber()], "\n\r");
+            $this->terminal->moveCursorToTop();
+            $this->terminal->moveCursorDown($newItem->getStartRowNumber());
+            echo rtrim($rows[$newItem->getStartRowNumber()], "\n\r");
 
-		} else {
+        } else {
 
-	        $this->terminal->clean();
-    	    $this->terminal->moveCursorToTop();
+            $this->terminal->clean();
+            $this->terminal->moveCursorToTop();
 
-	        foreach ($frame->getRows() as $row) {
-    	        echo $row;
-			}
+            foreach ($frame->getRows() as $row) {
+                echo $row;
+            }
 
-		}
+        }
 
         $this->currentFrame = $frame;
     }
@@ -309,9 +309,9 @@ class CliMenu
             );
         }, $rows);
 
-		$item->setNumberOfRows( count( $rows ) );
+        $item->setNumberOfRows( count( $rows ) );
 
-		return array( $rows, $item );
+        return array( $rows, $item );
     }
 
     /**

--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -165,8 +165,10 @@ class CliMenu
             switch ($input) {
                 case 'up':
                 case 'down':
+                    $previousItem = $this->getSelectedItem();
                     $this->moveSelection($input);
-                    $this->draw();
+                    $newItem = $this->getSelectedItem();
+                    $this->draw($previousItem, $newItem);
                     break;
                 case 'enter':
                     $this->executeCurrentItem();

--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -256,7 +256,6 @@ class CliMenu
         $frame->newLine(2);
 
         if ($previousItem && $newItem) {
-
             $rows = $frame->getRows();
 
             $this->terminal->moveCursorToTop();
@@ -266,16 +265,13 @@ class CliMenu
             $this->terminal->moveCursorToTop();
             $this->terminal->moveCursorDown($newItem->getStartRowNumber());
             echo rtrim($rows[$newItem->getStartRowNumber()], "\n\r");
-
         } else {
-
             $this->terminal->clean();
             $this->terminal->moveCursorToTop();
 
             foreach ($frame->getRows() as $row) {
                 echo $row;
             }
-
         }
 
         $this->currentFrame = $frame;
@@ -309,9 +305,9 @@ class CliMenu
             );
         }, $rows);
 
-        $item->setNumberOfRows( count( $rows ) );
+        $item->setNumberOfRows(count($rows));
 
-        return array( $rows, $item );
+        return array($rows, $item);
     }
 
     /**

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -25,9 +25,15 @@ class Frame implements \Countable
     public function addRows(array $params = []) : void
     {
         list($rows, $item) = $params;
-        if (!empty($item)) {
-            $item->setStartRowNumber(count($this->rows));
+
+        if (!is_array($rows)) {
+            $rows = $params;
+        } else {
+            if (!empty($item)) {
+                $item->setStartRowNumber(count($this->rows));
+            }
         }
+
         foreach ($rows as $row) {
             $this->rows[] = $row;
         }

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -22,8 +22,10 @@ class Frame implements \Countable
         }
     }
 
-    public function addRows(array $rows = []) : void
-    {
+    public function addRows(array $params = []) : void
+	{
+		list($rows, $item) = $params;
+		$item->setStartRowNumber(count($this->rows));
         foreach ($rows as $row) {
             $this->rows[] = $row;
         }

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -25,7 +25,9 @@ class Frame implements \Countable
     public function addRows(array $params = []) : void
     {
         list($rows, $item) = $params;
-        $item->setStartRowNumber(count($this->rows));
+        if (!empty($item)) {
+            $item->setStartRowNumber(count($this->rows));
+        }
         foreach ($rows as $row) {
             $this->rows[] = $row;
         }

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -2,6 +2,8 @@
 
 namespace PhpSchool\CliMenu;
 
+use PhpSchool\CliMenu\MenuItem\MenuItemInterface;
+
 /**
  * Represents the current screen being displayed
  * contains all rows of output
@@ -24,14 +26,11 @@ class Frame implements \Countable
 
     public function addRows(array $params = []) : void
     {
-        list($rows, $item) = $params;
-
-        if (!is_array($rows)) {
-            $rows = $params;
+        if (count($params) == 2 && is_array($params[0]) && $params[1] instanceof MenuItemInterface) {
+            list($rows, $item) = $params;
+            $item->setStartRowNumber(count($this->rows));
         } else {
-            if (!empty($item)) {
-                $item->setStartRowNumber(count($this->rows));
-            }
+            $rows = $params;
         }
 
         foreach ($rows as $row) {

--- a/src/Frame.php
+++ b/src/Frame.php
@@ -23,9 +23,9 @@ class Frame implements \Countable
     }
 
     public function addRows(array $params = []) : void
-	{
-		list($rows, $item) = $params;
-		$item->setStartRowNumber(count($this->rows));
+    {
+        list($rows, $item) = $params;
+        $item->setStartRowNumber(count($this->rows));
         foreach ($rows as $row) {
             $this->rows[] = $row;
         }

--- a/src/MenuItem/AsciiArtItem.php
+++ b/src/MenuItem/AsciiArtItem.php
@@ -32,6 +32,16 @@ class AsciiArtItem implements MenuItemInterface
      */
     private $artLength;
 
+	/**
+	 * @var int
+	 */
+	private $numberOfRows = 0;
+
+	/**
+	 * @var int
+	 */
+	private $startRowNumber = 0;
+
     public function __construct(string $text, string $position = self::POSITION_CENTER)
     {
         Assertion::inArray($position, [self::POSITION_CENTER, self::POSITION_RIGHT, self::POSITION_LEFT]);
@@ -41,12 +51,33 @@ class AsciiArtItem implements MenuItemInterface
         $this->artLength = max(array_map('mb_strlen', explode("\n", $text)));
     }
 
+	/**
+	 * Returns the number of terminal rows the item takes
+	 */
+	public function getNumberOfRows() {
+		return $this->numberOfRows;
+	}
+
+	/**
+	 * Sets the row number the item starts at in the frame
+	 */
+	public function setStartRowNumber(int $rowNumber) {
+		$this->startRowNumber = $rowNumber;
+	}
+
+	/**
+	 * Returns the row number the item starts at in the frame
+	 */
+	public function getStartRowNumber() {
+		return $this->startRowNumber;
+	}
+
     /**
      * The output text for the item
      */
     public function getRows(MenuStyle $style, bool $selected = false) : array
     {
-        return array_map(function ($row) use ($style) {
+        $rows = array_map(function ($row) use ($style) {
             $length = mb_strlen($row);
 
             $padding = $style->getContentWidth() - $length;
@@ -71,7 +102,11 @@ class AsciiArtItem implements MenuItemInterface
             }
 
             return $row;
-        }, explode("\n", $this->text));
+		}, explode("\n", $this->text));
+
+		$this->numberOfRows = count($rows);
+
+		return $rows;
     }
 
     /**

--- a/src/MenuItem/AsciiArtItem.php
+++ b/src/MenuItem/AsciiArtItem.php
@@ -32,15 +32,15 @@ class AsciiArtItem implements MenuItemInterface
      */
     private $artLength;
 
-	/**
-	 * @var int
-	 */
-	private $numberOfRows = 0;
+    /**
+     * @var int
+     */
+    private $numberOfRows = 0;
 
-	/**
-	 * @var int
-	 */
-	private $startRowNumber = 0;
+    /**
+     * @var int
+     */
+    private $startRowNumber = 0;
 
     public function __construct(string $text, string $position = self::POSITION_CENTER)
     {
@@ -51,26 +51,26 @@ class AsciiArtItem implements MenuItemInterface
         $this->artLength = max(array_map('mb_strlen', explode("\n", $text)));
     }
 
-	/**
-	 * Returns the number of terminal rows the item takes
-	 */
-	public function getNumberOfRows() {
-		return $this->numberOfRows;
-	}
+    /**
+     * Returns the number of terminal rows the item takes
+     */
+    public function getNumberOfRows() {
+        return $this->numberOfRows;
+    }
 
-	/**
-	 * Sets the row number the item starts at in the frame
-	 */
-	public function setStartRowNumber(int $rowNumber) {
-		$this->startRowNumber = $rowNumber;
-	}
+    /**
+     * Sets the row number the item starts at in the frame
+     */
+    public function setStartRowNumber(int $rowNumber) {
+        $this->startRowNumber = $rowNumber;
+    }
 
-	/**
-	 * Returns the row number the item starts at in the frame
-	 */
-	public function getStartRowNumber() {
-		return $this->startRowNumber;
-	}
+    /**
+     * Returns the row number the item starts at in the frame
+     */
+    public function getStartRowNumber() {
+        return $this->startRowNumber;
+    }
 
     /**
      * The output text for the item
@@ -102,11 +102,11 @@ class AsciiArtItem implements MenuItemInterface
             }
 
             return $row;
-		}, explode("\n", $this->text));
+        }, explode("\n", $this->text));
 
-		$this->numberOfRows = count($rows);
+        $this->numberOfRows = count($rows);
 
-		return $rows;
+        return $rows;
     }
 
     /**

--- a/src/MenuItem/AsciiArtItem.php
+++ b/src/MenuItem/AsciiArtItem.php
@@ -54,21 +54,24 @@ class AsciiArtItem implements MenuItemInterface
     /**
      * Returns the number of terminal rows the item takes
      */
-    public function getNumberOfRows() {
+    public function getNumberOfRows() : int
+    {
         return $this->numberOfRows;
     }
 
     /**
      * Sets the row number the item starts at in the frame
      */
-    public function setStartRowNumber(int $rowNumber) {
+    public function setStartRowNumber(int $rowNumber) : void
+    {
         $this->startRowNumber = $rowNumber;
     }
 
     /**
      * Returns the row number the item starts at in the frame
      */
-    public function getStartRowNumber() {
+    public function getStartRowNumber() : int
+    {
         return $this->startRowNumber;
     }
 

--- a/src/MenuItem/LineBreakItem.php
+++ b/src/MenuItem/LineBreakItem.php
@@ -20,15 +20,15 @@ class LineBreakItem implements MenuItemInterface
      */
     private $lines;
 
-	/**
-	 * @var int
-	 */
-	private $numberOfRows = 0;
+    /**
+     * @var int
+     */
+    private $numberOfRows = 0;
 
-	/**
-	 * @var int
-	 */
-	private $startRowNumber = 0;
+    /**
+     * @var int
+     */
+    private $startRowNumber = 0;
 
     public function __construct(string $breakChar = ' ', int $lines = 1)
     {
@@ -36,26 +36,26 @@ class LineBreakItem implements MenuItemInterface
         $this->lines     = $lines;
     }
 
-	/**
-	 * Returns the number of terminal rows the item takes
-	 */
-	public function getNumberOfRows() {
-		return $this->numberOfRows;
-	}
+    /**
+     * Returns the number of terminal rows the item takes
+     */
+    public function getNumberOfRows() {
+        return $this->numberOfRows;
+    }
 
-	/**
-	 * Sets the row number the item starts at in the frame
-	 */
-	public function setStartRowNumber(int $rowNumber) {
-		$this->startRowNumber = $rowNumber;
-	}
+    /**
+     * Sets the row number the item starts at in the frame
+     */
+    public function setStartRowNumber(int $rowNumber) {
+        $this->startRowNumber = $rowNumber;
+    }
 
-	/**
-	 * Returns the row number the item starts at in the frame
-	 */
-	public function getStartRowNumber() {
-		return $this->startRowNumber;
-	}
+    /**
+     * Returns the row number the item starts at in the frame
+     */
+    public function getStartRowNumber() {
+        return $this->startRowNumber;
+    }
 
     /**
      * The output text for the item
@@ -70,9 +70,9 @@ class LineBreakItem implements MenuItemInterface
             ), $this->lines))
         );
 
-		$this->numberOfRows = count($rows);
+        $this->numberOfRows = count($rows);
 
-		return $rows;
+        return $rows;
     }
 
     /**

--- a/src/MenuItem/LineBreakItem.php
+++ b/src/MenuItem/LineBreakItem.php
@@ -20,24 +20,59 @@ class LineBreakItem implements MenuItemInterface
      */
     private $lines;
 
+	/**
+	 * @var int
+	 */
+	private $numberOfRows = 0;
+
+	/**
+	 * @var int
+	 */
+	private $startRowNumber = 0;
+
     public function __construct(string $breakChar = ' ', int $lines = 1)
     {
         $this->breakChar = $breakChar;
         $this->lines     = $lines;
     }
 
+	/**
+	 * Returns the number of terminal rows the item takes
+	 */
+	public function getNumberOfRows() {
+		return $this->numberOfRows;
+	}
+
+	/**
+	 * Sets the row number the item starts at in the frame
+	 */
+	public function setStartRowNumber(int $rowNumber) {
+		$this->startRowNumber = $rowNumber;
+	}
+
+	/**
+	 * Returns the row number the item starts at in the frame
+	 */
+	public function getStartRowNumber() {
+		return $this->startRowNumber;
+	}
+
     /**
      * The output text for the item
      */
     public function getRows(MenuStyle $style, bool $selected = false) : array
     {
-        return explode(
+        $rows = explode(
             "\n",
             rtrim(str_repeat(sprintf(
                 "%s\n",
                 mb_substr(str_repeat($this->breakChar, $style->getContentWidth()), 0, $style->getContentWidth())
             ), $this->lines))
         );
+
+		$this->numberOfRows = count($rows);
+
+		return $rows;
     }
 
     /**

--- a/src/MenuItem/LineBreakItem.php
+++ b/src/MenuItem/LineBreakItem.php
@@ -39,21 +39,24 @@ class LineBreakItem implements MenuItemInterface
     /**
      * Returns the number of terminal rows the item takes
      */
-    public function getNumberOfRows() {
+    public function getNumberOfRows() : int
+    {
         return $this->numberOfRows;
     }
 
     /**
      * Sets the row number the item starts at in the frame
      */
-    public function setStartRowNumber(int $rowNumber) {
+    public function setStartRowNumber(int $rowNumber) : void
+    {
         $this->startRowNumber = $rowNumber;
     }
 
     /**
      * Returns the row number the item starts at in the frame
      */
-    public function getStartRowNumber() {
+    public function getStartRowNumber() : int
+    {
         return $this->startRowNumber;
     }
 

--- a/src/MenuItem/MenuItemInterface.php
+++ b/src/MenuItem/MenuItemInterface.php
@@ -9,6 +9,21 @@ use PhpSchool\CliMenu\MenuStyle;
  */
 interface MenuItemInterface
 {
+	/**
+	 * Returns the number of terminal rows the item takes
+	 */
+	public function getNumberOfRows() : int;
+
+	/**
+	 * Sets the row number the item starts at in the frame
+	 */
+	public function setStartRowNumber(int $rowNumber) : void;
+
+	/**
+	 * Returns the row number the item starts at in the frame
+	 */
+	public function getStartRowNumber() : int;
+
     /**
      * The output text for the item
      */

--- a/src/MenuItem/MenuItemInterface.php
+++ b/src/MenuItem/MenuItemInterface.php
@@ -9,20 +9,20 @@ use PhpSchool\CliMenu\MenuStyle;
  */
 interface MenuItemInterface
 {
-	/**
-	 * Returns the number of terminal rows the item takes
-	 */
-	public function getNumberOfRows() : int;
+    /**
+     * Returns the number of terminal rows the item takes
+     */
+    public function getNumberOfRows() : int;
 
-	/**
-	 * Sets the row number the item starts at in the frame
-	 */
-	public function setStartRowNumber(int $rowNumber) : void;
+    /**
+     * Sets the row number the item starts at in the frame
+     */
+    public function setStartRowNumber(int $rowNumber) : void;
 
-	/**
-	 * Returns the row number the item starts at in the frame
-	 */
-	public function getStartRowNumber() : int;
+    /**
+     * Returns the row number the item starts at in the frame
+     */
+    public function getStartRowNumber() : int;
 
     /**
      * The output text for the item

--- a/src/MenuItem/SelectableTrait.php
+++ b/src/MenuItem/SelectableTrait.php
@@ -38,21 +38,24 @@ trait SelectableTrait
     /**
      * Returns the number of terminal rows the item takes
      */
-    public function getNumberOfRows() {
+    public function getNumberOfRows() : int
+    {
         return $this->numberOfRows;
     }
 
     /**
      * Sets the row number the item starts at in the frame
      */
-    public function setStartRowNumber(int $rowNumber) {
+    public function setStartRowNumber(int $rowNumber) : void
+    {
         $this->startRowNumber = $rowNumber;
     }
 
     /**
      * Returns the row number the item starts at in the frame
      */
-    public function getStartRowNumber() {
+    public function getStartRowNumber() : int
+    {
         return $this->startRowNumber;
     }
 

--- a/src/MenuItem/SelectableTrait.php
+++ b/src/MenuItem/SelectableTrait.php
@@ -23,7 +23,38 @@ trait SelectableTrait
     /**
      * @var bool
      */
-    private $disabled = false;
+	private $disabled = false;
+
+	/**
+	 * @var int
+	 */
+	private $numberOfRows = 0;
+
+	/**
+	 * @var int
+	 */
+	private $startRowNumber = 0;
+
+	/**
+	 * Returns the number of terminal rows the item takes
+	 */
+	public function getNumberOfRows() {
+		return $this->numberOfRows;
+	}
+
+	/**
+	 * Sets the row number the item starts at in the frame
+	 */
+	public function setStartRowNumber(int $rowNumber) {
+		$this->startRowNumber = $rowNumber;
+	}
+
+	/**
+	 * Returns the row number the item starts at in the frame
+	 */
+	public function getStartRowNumber() {
+		return $this->startRowNumber;
+	}
 
     /**
      * The output text for the item
@@ -43,7 +74,9 @@ trait SelectableTrait
                 $length,
                 sprintf("\n%s", str_repeat(' ', mb_strlen($marker)))
             )
-        );
+		);
+
+		$this->numberOfRows = count($rows);
 
         return array_map(function ($row, $key) use ($style, $length) {
             $text = $this->disabled ? $style->getDisabledItemText($row) : $row;

--- a/src/MenuItem/SelectableTrait.php
+++ b/src/MenuItem/SelectableTrait.php
@@ -23,38 +23,38 @@ trait SelectableTrait
     /**
      * @var bool
      */
-	private $disabled = false;
+    private $disabled = false;
 
-	/**
-	 * @var int
-	 */
-	private $numberOfRows = 0;
+    /**
+     * @var int
+     */
+    private $numberOfRows = 0;
 
-	/**
-	 * @var int
-	 */
-	private $startRowNumber = 0;
+    /**
+     * @var int
+     */
+    private $startRowNumber = 0;
 
-	/**
-	 * Returns the number of terminal rows the item takes
-	 */
-	public function getNumberOfRows() {
-		return $this->numberOfRows;
-	}
+    /**
+     * Returns the number of terminal rows the item takes
+     */
+    public function getNumberOfRows() {
+        return $this->numberOfRows;
+    }
 
-	/**
-	 * Sets the row number the item starts at in the frame
-	 */
-	public function setStartRowNumber(int $rowNumber) {
-		$this->startRowNumber = $rowNumber;
-	}
+    /**
+     * Sets the row number the item starts at in the frame
+     */
+    public function setStartRowNumber(int $rowNumber) {
+        $this->startRowNumber = $rowNumber;
+    }
 
-	/**
-	 * Returns the row number the item starts at in the frame
-	 */
-	public function getStartRowNumber() {
-		return $this->startRowNumber;
-	}
+    /**
+     * Returns the row number the item starts at in the frame
+     */
+    public function getStartRowNumber() {
+        return $this->startRowNumber;
+    }
 
     /**
      * The output text for the item
@@ -74,9 +74,9 @@ trait SelectableTrait
                 $length,
                 sprintf("\n%s", str_repeat(' ', mb_strlen($marker)))
             )
-		);
+        );
 
-		$this->numberOfRows = count($rows);
+        $this->numberOfRows = count($rows);
 
         return array_map(function ($row, $key) use ($style, $length) {
             $text = $this->disabled ? $style->getDisabledItemText($row) : $row;

--- a/src/MenuItem/StaticItem.php
+++ b/src/MenuItem/StaticItem.php
@@ -34,21 +34,24 @@ class StaticItem implements MenuItemInterface
     /**
      * Returns the number of terminal rows the item takes
      */
-    public function getNumberOfRows() {
+    public function getNumberOfRows() : int
+    {
         return $this->numberOfRows;
     }
 
     /**
      * Sets the row number the item starts at in the frame
      */
-    public function setStartRowNumber(int $rowNumber) {
+    public function setStartRowNumber(int $rowNumber) : void
+    {
         $this->startRowNumber = $rowNumber;
     }
 
     /**
      * Returns the row number the item starts at in the frame
      */
-    public function getStartRowNumber() {
+    public function getStartRowNumber() : int
+    {
         return $this->startRowNumber;
     }
 

--- a/src/MenuItem/StaticItem.php
+++ b/src/MenuItem/StaticItem.php
@@ -16,52 +16,52 @@ class StaticItem implements MenuItemInterface
      */
     private $text;
 
-	/**
-	 * @var int
-	 */
-	private $numberOfRows = 0;
+    /**
+     * @var int
+     */
+    private $numberOfRows = 0;
 
-	/**
-	 * @var int
-	 */
-	private $startRowNumber = 0;
+    /**
+     * @var int
+     */
+    private $startRowNumber = 0;
 
     public function __construct(string $text)
     {
         $this->text = $text;
     }
 
-	/**
-	 * Returns the number of terminal rows the item takes
-	 */
-	public function getNumberOfRows() {
-		return $this->numberOfRows;
-	}
+    /**
+     * Returns the number of terminal rows the item takes
+     */
+    public function getNumberOfRows() {
+        return $this->numberOfRows;
+    }
 
-	/**
-	 * Sets the row number the item starts at in the frame
-	 */
-	public function setStartRowNumber(int $rowNumber) {
-		$this->startRowNumber = $rowNumber;
-	}
+    /**
+     * Sets the row number the item starts at in the frame
+     */
+    public function setStartRowNumber(int $rowNumber) {
+        $this->startRowNumber = $rowNumber;
+    }
 
-	/**
-	 * Returns the row number the item starts at in the frame
-	 */
-	public function getStartRowNumber() {
-		return $this->startRowNumber;
-	}
+    /**
+     * Returns the row number the item starts at in the frame
+     */
+    public function getStartRowNumber() {
+        return $this->startRowNumber;
+    }
 
     /**
      * The output text for the item
      */
     public function getRows(MenuStyle $style, bool $selected = false) : array
     {
-		$rows = explode("\n", StringUtil::wordwrap($this->text, $style->getContentWidth()));
+        $rows = explode("\n", StringUtil::wordwrap($this->text, $style->getContentWidth()));
 
-		$this->numberOfRows = count($rows);
+        $this->numberOfRows = count($rows);
 
-		return $rows;
+        return $rows;
     }
 
     /**

--- a/src/MenuItem/StaticItem.php
+++ b/src/MenuItem/StaticItem.php
@@ -16,17 +16,52 @@ class StaticItem implements MenuItemInterface
      */
     private $text;
 
+	/**
+	 * @var int
+	 */
+	private $numberOfRows = 0;
+
+	/**
+	 * @var int
+	 */
+	private $startRowNumber = 0;
+
     public function __construct(string $text)
     {
         $this->text = $text;
     }
+
+	/**
+	 * Returns the number of terminal rows the item takes
+	 */
+	public function getNumberOfRows() {
+		return $this->numberOfRows;
+	}
+
+	/**
+	 * Sets the row number the item starts at in the frame
+	 */
+	public function setStartRowNumber(int $rowNumber) {
+		$this->startRowNumber = $rowNumber;
+	}
+
+	/**
+	 * Returns the row number the item starts at in the frame
+	 */
+	public function getStartRowNumber() {
+		return $this->startRowNumber;
+	}
 
     /**
      * The output text for the item
      */
     public function getRows(MenuStyle $style, bool $selected = false) : array
     {
-        return explode("\n", StringUtil::wordwrap($this->text, $style->getContentWidth()));
+		$rows = explode("\n", StringUtil::wordwrap($this->text, $style->getContentWidth()));
+
+		$this->numberOfRows = count($rows);
+
+		return $rows;
     }
 
     /**

--- a/src/Terminal/TerminalInterface.php
+++ b/src/Terminal/TerminalInterface.php
@@ -58,6 +58,16 @@ interface TerminalInterface
     public function moveCursorToTop() : void;
 
     /**
+     * Move the cursor up a specific number of rows
+     */
+    public function moveCursorUp(int $numberOfRows) : void;
+
+    /**
+     * Move the cursor down a specific number of rows
+     */
+    public function moveCursorDown(int $numberOfRows) : void;
+
+    /**
      * Move the cursor to the start of a specific row
      */
     public function moveCursorToRow(int $rowNumber) : void;

--- a/src/Terminal/UnixTerminal.php
+++ b/src/Terminal/UnixTerminal.php
@@ -188,6 +188,22 @@ class UnixTerminal implements TerminalInterface
     }
 
     /**
+     * Move the cursor up a specific number of rows
+     */
+    public function moveCursorUp(int $numberOfRows) : void
+    {
+        echo sprintf("\033[%dA", $numberOfRows);
+    }
+
+    /**
+     * Move the cursor down a specific number of rows
+     */
+    public function moveCursorDown(int $numberOfRows) : void
+    {
+        echo sprintf("\033[%dB", $numberOfRows);
+    }
+
+    /**
      * Move the cursor to the start of a specific row
      */
     public function moveCursorToRow(int $rowNumber) : void


### PR DESCRIPTION
Instead of the whole menu each time you move up and down in selections.
It performs much better and prevents a lot of stuttering.

I wasn't sure how I was supposed to launch the tests and such but I suspect that Travis will do it.

I don't make a lot of PRs on github, so let me know if I overlooked something regarding this process or if I didn't understand your coding standards.

Edit: I juste realized you use spaces instead of tabs, will fix this if tests are good.

Edit n°2: I could have used `moveCursorToRow()` instead of `moveCursorToTop() + moveCursorDown()` but performances are unexpectedly better using the latter.

Edit n°3: What I did with `drawMenuItem()` and `addRows()` isn't pretty, but I intended to keep BC without touching much of the code.

Edit n°4: Note sure how to add tests to hit those new lines, Codecov seems angry :)