### PR TITLE
Don't clean terminal on each redraw but...

### DIFF
--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -272,6 +272,9 @@ class CliMenu
         
         $this->terminal->moveCursorToTop();
         foreach ($frame->getRows() as $row) {
+            if ($row == "\n") {
+                $this->terminal->write("\033[2K");
+            }
             $this->terminal->write($row);
         }
         $this->terminal->write("\033[J");

--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -272,9 +272,9 @@ class CliMenu
         
         $this->terminal->moveCursorToTop();
         foreach ($frame->getRows() as $row) {
-            $this->terminal->write("\033[1E" . rtrim($row, "\r\n"));
+            $this->terminal->write($row);
         }
-        $this->terminal->write("\033[1E\033[J");
+        $this->terminal->write("\033[J");
 
         $this->currentFrame = $frame;
     }

--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -252,9 +252,6 @@ class CliMenu
      */
     protected function draw() : void
     {
-        $this->terminal->clean();
-        $this->terminal->moveCursorToTop();
-
         $frame = new Frame;
 
         $frame->newLine(2);
@@ -272,10 +269,12 @@ class CliMenu
         $frame->addRows($this->drawMenuItem(new LineBreakItem()));
 
         $frame->newLine(2);
-
+        
+        $this->terminal->moveCursorToTop();
         foreach ($frame->getRows() as $row) {
-            $this->terminal->write($row);
+            $this->terminal->write("\033[1E" . rtrim($row, "\r\n"));
         }
+        $this->terminal->write("\033[1E\033[J");
 
         $this->currentFrame = $frame;
     }


### PR DESCRIPTION
redraw directly on existing output !

It's different from my last PR but it correctly removes flickering (at least for me, others will have to test) so everything seems very smooth.

It uses ~`\033[1E` which means "move the cursor to the beginning of the next line" and~ `\033[J` which means "Clear everything from the cursor to the end of the terminal".
I guess those two could be made into UnixTerminal functions.

Edit: Last change removed the use of \033[1E to put back new lines.