### PR TITLE
Allow preparing of subMenus

### DIFF
--- a/src/CliMenuBuilder.php
+++ b/src/CliMenuBuilder.php
@@ -156,11 +156,11 @@ class CliMenuBuilder
         if (!empty($subMenuBuilder)) {
             $subMenuBuilder->setParent($this);
             $this->subMenuBuilders[$id] = $subMenuBuilder;
+            return $this;
         } else {
             $this->subMenuBuilders[$id] = new static($this);
+            return $this->subMenuBuilders[$id];
         }
-
-        return $this->subMenuBuilders[$id];
     }
 
     /**

--- a/src/CliMenuBuilder.php
+++ b/src/CliMenuBuilder.php
@@ -150,10 +150,15 @@ class CliMenuBuilder
     /**
      * Add a submenu with a string identifier
      */
-    public function addSubMenu(string $id) : CliMenuBuilder
+    public function addSubMenu(string $id, CliMenuBuilder $subMenuBuilder = null) : CliMenuBuilder
     {
         $this->menuItems[]          = $id;
-        $this->subMenuBuilders[$id] = new static($this);
+        if (!empty($subMenuBuilder)) {
+            $subMenuBuilder->setParent($this);
+            $this->subMenuBuilders[$id] = $subMenuBuilder;
+        } else {
+            $this->subMenuBuilders[$id] = new static($this);
+        }
 
         return $this->subMenuBuilders[$id];
     }


### PR DESCRIPTION
This allows passing another CliMenuBuilder as the second argument of CliMenuBuilder::addSubMenu().

Why this request ? Because I think it gives more control for custom menus and I think it's easier to write more organized code that way.

Usage example:

```php
$subMenu1 = (new CliMenuBuilder)
    ->setTitle('Some title')
    -> ... ; // No ->build() at the end !

$subMenu2 = (new CliMenuBuilder)
    ->setTitle('Some other title')
    -> ... ; // No ->build() at the end !

$mainMenu = (new CliMenuBuilder)
    ->setTitle('My awesome menu')
    ->addSubMenu('menu1', $subMenu1)
    ->addSubMenu('menu2', $subMenu2)
    ->build();
```