### PR TITLE
Adding public functions addItems and setItems

### DIFF
--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -144,6 +144,30 @@ class CliMenu
     }
 
     /**
+     * Add multiple Items to the menu
+     */
+    public function addItems(array $items) : void
+    {
+        foreach ($items as $item) {
+            $this->items[] = $item;
+        }
+
+        if (count($this->items) === count($items)) {
+            $this->selectFirstItem();
+        }
+    }
+
+    /**
+     * Set Items of the menu
+     */
+    public function setItems(array $items) : void
+    {
+        $this->items = $items;
+
+        $this->selectFirstItem();
+    }
+
+    /**
      * Set the selected pointer to the first selectable item
      */
     private function selectFirstItem() : void


### PR DESCRIPTION
The addItems one is simply an extension of addItem.
The setItems one allow to completly change the content of the menu by replacing all items.

I use setItems mainly when showing paginated lists so that I just create new items and shove them inside the menu, without rebuild it entirely.