### PR TITLE
Fix go back bug

### DIFF
--- a/src/Action/GoBackAction.php
+++ b/src/Action/GoBackAction.php
@@ -12,7 +12,7 @@ class GoBackAction
     public function __invoke(CliMenu $menu) : void
     {
         if ($parent = $menu->getParent()) {
-            $menu->close();
+            $menu->closeThis();
             $parent->open();
         }
     }


### PR DESCRIPTION
Seems like submenus are currently unusable, this fixes it.
(When returning from a submenu, the whole thing freezes, and you can't move the selection anymore)