### PR TITLE
Force enableCursor in tearDownTerminal

### DIFF
--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -119,6 +119,7 @@ class CliMenu
      */
     protected function tearDownTerminal() : void
     {
+        $this->terminal->enableCursor();
         $this->terminal->restoreOriginalConfiguration();
     }
 


### PR DESCRIPTION
This should be an issue instead of a PR, closing this.