### PR TITLE
Adds alternateText to AsciiArtItem

### DIFF
--- a/src/CliMenuBuilder.php
+++ b/src/CliMenuBuilder.php
@@ -136,13 +136,9 @@ class CliMenuBuilder
         return $this;
     }
 
-    public function addAsciiArt(string $art, string $position = AsciiArtItem::POSITION_CENTER) : self
+    public function addAsciiArt(string $art, string $position = AsciiArtItem::POSITION_CENTER, string $alt) : self
     {
-        $asciiArtItem = new AsciiArtItem($art, $position);
-
-        if ($asciiArtItem->getArtLength() <= $this->getMenuStyle()->getContentWidth()) {
-            $this->addMenuItem($asciiArtItem);
-        }
+        $this->addMenuItem(new AsciiArtItem($art, $position, $alt));
 
         return $this;
     }

--- a/src/MenuItem/AsciiArtItem.php
+++ b/src/MenuItem/AsciiArtItem.php
@@ -28,16 +28,22 @@ class AsciiArtItem implements MenuItemInterface
     private $position;
 
     /**
+     * @var string
+     */
+    private $alternateText;
+
+    /**
      * @var int
      */
     private $artLength;
 
-    public function __construct(string $text, string $position = self::POSITION_CENTER)
+    public function __construct(string $text, string $position = self::POSITION_CENTER, string $alt = '')
     {
         Assertion::inArray($position, [self::POSITION_CENTER, self::POSITION_RIGHT, self::POSITION_LEFT]);
         
         $this->text      = $text;
         $this->position  = $position;
+        $this->alternateText = $alt;
         $this->artLength = max(array_map('mb_strlen', explode("\n", $text)));
     }
 
@@ -46,6 +52,11 @@ class AsciiArtItem implements MenuItemInterface
      */
     public function getRows(MenuStyle $style, bool $selected = false) : array
     {
+        if ($this->artLength > $style->getContentWidth()) {
+            $alternate = new StaticItem($this->alternateText);
+            return $alternate->getRows($style, false);
+        }
+
         return array_map(function ($row) use ($style) {
             $length = mb_strlen($row);
 


### PR DESCRIPTION
This will replace the AsciiArtItem with a StaticItem if the art is to big to fit in the menu/screen.

The new output will ignore position and be left aligned. Will print an empty line by default.