### PR TITLE
Fix centering ascii art

### DIFF
--- a/src/MenuItem/AsciiArtItem.php
+++ b/src/MenuItem/AsciiArtItem.php
@@ -73,8 +73,7 @@ class AsciiArtItem implements MenuItemInterface
                     break;
                 case self::POSITION_CENTER:
                 default:
-                    $row = rtrim($row);
-                    $padding = $padding - ($this->artLength - mb_strlen($row));
+                    $padding = $padding - ($this->artLength - $length);
                     $left = ceil($padding/2);
                     $right = $padding - $left;
                     $row = sprintf('%s%s%s', str_repeat(' ', $left), $row, str_repeat(' ', $right));

--- a/test/MenuItem/AsciiArtItemTest.php
+++ b/test/MenuItem/AsciiArtItemTest.php
@@ -96,6 +96,15 @@ class AsciiArtItemTest extends TestCase
             ],
             $item->getRows($menuStyle)
         );
+
+        $item = new AsciiArtItem("    //    \n//////////", AsciiArtItem::POSITION_CENTER);
+        $this->assertEquals(
+            [
+                "    //    ",
+                "//////////",
+            ],
+            $item->getRows($menuStyle)
+        );
     }
 
     public function testGetRowsCenterAlignedWithOddWidth() : void
@@ -112,6 +121,15 @@ class AsciiArtItemTest extends TestCase
             [
                 "     //    ",
                 "     //    ",
+            ],
+            $item->getRows($menuStyle)
+        );
+
+        $item = new AsciiArtItem("    //    \n//////////", AsciiArtItem::POSITION_CENTER);
+        $this->assertEquals(
+            [
+                "     //    ",
+                " //////////",
             ],
             $item->getRows($menuStyle)
         );


### PR DESCRIPTION
Centering ascii art where some lines have trailing spaces are all messed up. This fixes it.
Example of what doesn't work before the fix (select with mouse to see trailing white space):
```php
$art = <<<ART
        _ __ _        
       / |..| \       
       \/ || \/       
        |_''_|        
      PHP SCHOOL      
LEARNING FOR ELEPHANTS
ART;

// What centering actually outputs in a 76 columns width menu:
                               _ __ _                       
                               / |..| \                       
                               \/ || \/                       
                               |_''_|                       
                              PHP SCHOOL                        
                           LEARNING FOR ELEPHANTS                           
```

Doesn't affect anything else.