### PR TITLE
margin out of contentWidth + add menu centering

### DIFF
--- a/examples/basic-centered.php
+++ b/examples/basic-centered.php
@@ -1,0 +1,25 @@
+<?php
+
+use PhpSchool\CliMenu\CliMenu;
+use PhpSchool\CliMenu\CliMenuBuilder;
+
+require_once(__DIR__ . '/../vendor/autoload.php');
+
+$itemCallable = function (CliMenu $menu) {
+    echo $menu->getSelectedItem()->getText();
+};
+
+$menu = (new CliMenuBuilder)
+    ->setTitle('Basic CLI Menu')
+    ->addItem('First Item', $itemCallable)
+    ->addItem('Make menu wider', function (CliMenu $menu) {
+        $menu->getStyle()->setWidth($menu->getStyle()->getWidth() + 10);
+        $menu->redraw();
+    })
+    ->addItem('Third Item', $itemCallable)
+    ->addLineBreak('-')
+    ->setWidth(70)
+    ->setMarginAuto()
+    ->build();
+
+$menu->open();

--- a/src/CliMenuBuilder.php
+++ b/src/CliMenuBuilder.php
@@ -230,8 +230,18 @@ class CliMenuBuilder
         return $this;
     }
 
+    public function setMarginAuto() : self
+    {
+        $this->style['marginAuto'] = true;
+        
+        return $this;
+    }
+
     public function setMargin(int $margin) : self
     {
+        Assertion::greaterOrEqualThan($margin, 0);
+        
+        $this->style['marginAuto'] = false;
         $this->style['margin'] = $margin;
 
         return $this;
@@ -320,17 +330,20 @@ class CliMenuBuilder
 
     private function buildStyle() : MenuStyle
     {
-        return (new MenuStyle($this->terminal))
+        $style = (new MenuStyle($this->terminal))
             ->setFg($this->style['fg'])
             ->setBg($this->style['bg'])
             ->setWidth($this->style['width'])
             ->setPadding($this->style['padding'])
-            ->setMargin($this->style['margin'])
             ->setSelectedMarker($this->style['selectedMarker'])
             ->setUnselectedMarker($this->style['unselectedMarker'])
             ->setItemExtra($this->style['itemExtra'])
             ->setDisplaysExtra($this->style['displaysExtra'])
             ->setTitleSeparator($this->style['titleSeparator']);
+
+        $this->style['marginAuto'] ? $style->setMarginAuto() : $style->setMargin($this->style['margin']);
+        
+        return $style;
     }
 
     /**

--- a/src/Dialogue/Dialogue.php
+++ b/src/Dialogue/Dialogue.php
@@ -74,7 +74,7 @@ abstract class Dialogue
         //x
         $parentStyle        = $this->parentMenu->getStyle();
         $dialogueHalfLength = (mb_strlen($this->text) + ($this->style->getPadding() * 2)) / 2;
-        $widthHalfLength    = ceil($parentStyle->getWidth() / 2);
+        $widthHalfLength    = ceil($parentStyle->getWidth() / 2 + $parentStyle->getMargin());
         $this->x            = $widthHalfLength - $dialogueHalfLength;
     }
 

--- a/src/Input/InputIO.php
+++ b/src/Input/InputIO.php
@@ -132,7 +132,7 @@ class InputIO
 
         $parentStyle     = $this->parentMenu->getStyle();
         $halfWidth       = ($width + ($input->getStyle()->getPadding() * 2)) / 2;
-        $parentHalfWidth = ceil($parentStyle->getWidth() / 2);
+        $parentHalfWidth = ceil($parentStyle->getWidth() / 2 + $parentStyle->getMargin());
 
         return $parentHalfWidth - $halfWidth;
     }

--- a/src/MenuStyle.php
+++ b/src/MenuStyle.php
@@ -233,7 +233,7 @@ class MenuStyle
      */
     protected function calculateContentWidth() : void
     {
-        $this->contentWidth = $this->width - ($this->padding*2) - ($this->margin*2);
+        $this->contentWidth = $this->width - ($this->padding*2);
     }
 
     public function getFg() : string
@@ -267,13 +267,14 @@ class MenuStyle
 
     public function setWidth(int $width) : self
     {
-        $availableWidth = $this->terminal->getWidth() - ($this->margin * 2) - ($this->padding * 2);
-
-        if ($width >= $availableWidth) {
-            $width = $availableWidth;
+        if ($width >= $this->terminal->getWidth()) {
+            $width = $this->terminal->getWidth();
         }
 
         $this->width = $width;
+        if ($this->margin === -1) {
+            $this->setMargin(-1);
+        }
         $this->calculateContentWidth();
 
         return $this;
@@ -300,9 +301,11 @@ class MenuStyle
 
     public function setMargin(int $margin) : self
     {
-        $this->margin = $margin;
-
-        $this->calculateContentWidth();
+        if ($this->margin === -1) {
+            $this->margin = floor(($this->terminal->getWidth() - $this->width) / 2);
+        } else {
+            $this->margin = $margin;
+        }
 
         return $this;
     }

--- a/src/MenuStyle.php
+++ b/src/MenuStyle.php
@@ -301,7 +301,7 @@ class MenuStyle
 
     public function setMargin(int $margin) : self
     {
-        if ($this->margin === -1) {
+        if ($margin === -1) {
             $this->margin = floor(($this->terminal->getWidth() - $this->width) / 2);
         } else {
             $this->margin = $margin;

--- a/src/MenuStyle.php
+++ b/src/MenuStyle.php
@@ -74,6 +74,11 @@ class MenuStyle
     private $titleSeparator;
 
     /**
+     * @var bool
+     */
+    private $marginAuto = false;
+
+    /**
      * Default Values
      *
      * @var array
@@ -89,6 +94,7 @@ class MenuStyle
         'itemExtra' => '✔',
         'displaysExtra' => false,
         'titleSeparator' => '=',
+        'marginAuto' => false,
     ];
 
     public static function getDefaultStyleValues() : array
@@ -233,7 +239,7 @@ class MenuStyle
      */
     protected function calculateContentWidth() : void
     {
-        $this->contentWidth = $this->width - ($this->padding*2);
+        $this->contentWidth = $this->width - ($this->padding * 2);
     }
 
     public function getFg() : string
@@ -272,8 +278,8 @@ class MenuStyle
         }
 
         $this->width = $width;
-        if ($this->margin === -1) {
-            $this->setMargin(-1);
+        if ($this->marginAuto) {
+            $this->setMarginAuto();
         }
         $this->calculateContentWidth();
 
@@ -299,13 +305,18 @@ class MenuStyle
         return $this->margin;
     }
 
+    public function setMarginAuto() : self
+    {
+        $this->marginAuto = true;
+        $this->margin = floor(($this->terminal->getWidth() - $this->width) / 2);
+        
+        return $this;
+    }
+
     public function setMargin(int $margin) : self
     {
-        if ($margin === -1) {
-            $this->margin = floor(($this->terminal->getWidth() - $this->width) / 2);
-        } else {
-            $this->margin = $margin;
-        }
+        $this->marginAuto = false;
+        $this->margin = $margin;
 
         return $this;
     }

--- a/test/CliMenuBuilderTest.php
+++ b/test/CliMenuBuilderTest.php
@@ -437,6 +437,93 @@ class CliMenuBuilderTest extends TestCase
 
         (new CliMenuBuilder)->disableMenu();
     }
+
+    /**
+     * @dataProvider marginBelowZeroProvider
+     */
+    public function testSetMarginThrowsExceptionIfValueIsNotZeroOrAbove(int $value) : void
+    {
+        self::expectException(\Assert\InvalidArgumentException::class);
+        
+        
+        (new CliMenuBuilder)->setMargin($value);
+    }
+
+    public function marginBelowZeroProvider() : array
+    {
+        return [[-1], [-2], [-10]];
+    }
+
+    /**
+     * @dataProvider marginAboveZeroProvider
+     */
+    public function testSetMarginAcceptsZeroAndPositiveIntegers(int $value) : void
+    {
+        $menu = (new CliMenuBuilder)->setMargin($value)->build();
+        
+        self::assertSame($value, $menu->getStyle()->getMargin());
+    }
+
+    public function marginAboveZeroProvider() : array
+    {
+        return [[0], [1], [10], [50]];
+    }
+
+    public function testSetMarginAutoAutomaticallyCalculatesMarginToCenter() : void
+    {
+        $terminal = self::createMock(Terminal::class);
+        $terminal
+            ->expects($this->any())
+            ->method('getWidth')
+            ->will($this->returnValue(200));
+
+        $builder = new CliMenuBuilder;
+        $menu = $builder
+            ->setTerminal($terminal)
+            ->setMarginAuto()
+            ->setWidth(100)
+            ->build();
+        
+        self::assertSame(50, $menu->getStyle()->getMargin());
+    }
+
+    public function testSetMarginAutoOverwritesSetMargin() : void
+    {
+        $terminal = self::createMock(Terminal::class);
+        $terminal
+            ->expects($this->any())
+            ->method('getWidth')
+            ->will($this->returnValue(200));
+
+        $builder = new CliMenuBuilder;
+        $menu = $builder
+            ->setTerminal($terminal)
+            ->setMargin(10)
+            ->setMarginAuto()
+            ->setWidth(100)
+            ->build();
+
+        self::assertSame(50, $menu->getStyle()->getMargin());
+    }
+
+    public function testSetMarginManuallyOverwritesSetMarginAuto() : void
+    {
+        $terminal = self::createMock(Terminal::class);
+        $terminal
+            ->expects($this->any())
+            ->method('getWidth')
+            ->will($this->returnValue(200));
+
+        $builder = new CliMenuBuilder;
+        $menu = $builder
+            ->setTerminal($terminal)
+            ->setMarginAuto()
+            ->setMargin(10)
+            ->setWidth(100)
+            ->build();
+
+        self::assertSame(10, $menu->getStyle()->getMargin());
+    }
     
     private function checkItems(CliMenu $menu, array $expected) : void
     {

--- a/test/CliMenuTest.php
+++ b/test/CliMenuTest.php
@@ -38,7 +38,7 @@ class CliMenuTest extends TestCase
 
         $this->terminal->expects($this->any())
             ->method('getWidth')
-            ->willReturn(50);
+            ->willReturn(46);
 
         $this->terminal->expects($this->any())
             ->method('write')

--- a/test/Dialogue/ConfirmTest.php
+++ b/test/Dialogue/ConfirmTest.php
@@ -35,7 +35,7 @@ class ConfirmTest extends TestCase
 
         $this->terminal->expects($this->any())
             ->method('getWidth')
-            ->willReturn(50);
+            ->willReturn(46);
 
         $this->terminal->expects($this->any())
             ->method('write')

--- a/test/Dialogue/FlashTest.php
+++ b/test/Dialogue/FlashTest.php
@@ -35,7 +35,7 @@ class FlashTest extends TestCase
 
         $this->terminal->expects($this->any())
             ->method('getWidth')
-            ->willReturn(50);
+            ->willReturn(46);
 
         $this->terminal->expects($this->any())
             ->method('write')

--- a/test/MenuStyleTest.php
+++ b/test/MenuStyleTest.php
@@ -160,7 +160,7 @@ class MenuStyleTest extends TestCase
         $style->setPadding(5);
         $style->setMargin(5);
 
-        static::assertSame(280, $style->getContentWidth());
+        static::assertSame(290, $style->getContentWidth());
     }
 
     public function testRightHandPaddingCalculation() : void
@@ -171,6 +171,46 @@ class MenuStyleTest extends TestCase
         $style->setPadding(5);
         $style->setMargin(5);
 
-        static::assertSame(235, $style->getRightHandPadding(50));
+        static::assertSame(245, $style->getRightHandPadding(50));
+    }
+
+    public function testMargin() : void
+    {
+        $style = $this->getMenuStyle();
+
+        $style->setWidth(300);
+        $style->setPadding(5);
+        $style->setMargin(5);
+
+        self::assertSame(5, $style->getMargin());
+    }
+    
+    public function testMarginAutoCenters() : void
+    {
+        $style = $this->getMenuStyle();
+
+        $style->setWidth(300);
+        $style->setPadding(5);
+        $style->setMarginAuto();
+
+        self::assertSame(100, $style->getMargin());
+        self::assertSame(290, $style->getContentWidth());
+    }
+
+    public function testModifyWithWhenMarginAutoIsEnabledRecalculatesMargin() : void
+    {
+        $style = $this->getMenuStyle();
+
+        $style->setWidth(300);
+        $style->setPadding(5);
+        $style->setMarginAuto();
+
+        self::assertSame(100, $style->getMargin());
+        self::assertSame(290, $style->getContentWidth());
+        
+        $style->setWidth(400);
+
+        self::assertSame(50, $style->getMargin());
+        self::assertSame(390, $style->getContentWidth());
     }
 }


### PR DESCRIPTION
Ok so this makes the whole "width" thing more consistent. It now works like border-box in CSS (it includes the padding and borders but not the margin):
![firefox_2018-05-05_19-05-08](https://user-images.githubusercontent.com/5318258/39661165-f5d172a2-5098-11e8-998b-1a14bfd955e2.png)

This prevents PHP notices and improves rendered output when values are off the charts.
_The following was made with width = 120, padding = 10 and margin = 120 on a 237 column terminal._

**Before PR (this also throws notices because negative values are passed to str_repeat):**
![mintty_2018-05-05_19-12-33](https://user-images.githubusercontent.com/5318258/39661190-7365d172-5099-11e8-8118-f5ff68159a2a.png)
**After PR:**
![mintty_2018-05-05_19-13-09](https://user-images.githubusercontent.com/5318258/39661191-75f69aca-5099-11e8-984e-c4ff6ff87810.png)


It also adds the possibility to automatically center the whole menu by setting margins to `-1`. I wanted to set it to 'auto' instead but since it's already typehinted to int and all, I thought -1 was good enough. This can be changed though.

Anyway let me know what you think.