### PR TITLE
Ascii art refactor

### DIFF
--- a/src/MenuItem/AsciiArtItem.php
+++ b/src/MenuItem/AsciiArtItem.php
@@ -59,21 +59,17 @@ class AsciiArtItem implements MenuItemInterface
             return $alternate->getRows($style, false);
         }
 
-        return array_map(function ($row) use ($style) {
-            $length = mb_strlen($row);
-
-            $padding = $style->getContentWidth() - $length;
-
+        $padding = $style->getContentWidth() - $this->artLength;
+        
+        return array_map(function ($row) use ($style, $padding) {
             switch ($this->position) {
                 case self::POSITION_LEFT:
                     break;
                 case self::POSITION_RIGHT:
-                    $padding -= ($this->artLength - $length);
                     $row = sprintf('%s%s', str_repeat(' ', $padding), $row);
                     break;
                 case self::POSITION_CENTER:
                 default:
-                    $padding -= ($this->artLength - $length);
                     $left = ceil($padding / 2);
                     $row = sprintf('%s%s', str_repeat(' ', $left), $row);
                     break;

--- a/src/MenuItem/AsciiArtItem.php
+++ b/src/MenuItem/AsciiArtItem.php
@@ -61,7 +61,7 @@ class AsciiArtItem implements MenuItemInterface
 
         $padding = $style->getContentWidth() - $this->artLength;
         
-        return array_map(function ($row) use ($style, $padding) {
+        return array_map(function ($row) use ($padding) {
             switch ($this->position) {
                 case self::POSITION_LEFT:
                     break;

--- a/src/MenuItem/AsciiArtItem.php
+++ b/src/MenuItem/AsciiArtItem.php
@@ -80,7 +80,7 @@ class AsciiArtItem implements MenuItemInterface
                     break;
             }
 
-            return $row;
+            return rtrim($row, ' ');
         }, explode("\n", $this->text));
     }
 

--- a/src/MenuItem/AsciiArtItem.php
+++ b/src/MenuItem/AsciiArtItem.php
@@ -41,7 +41,9 @@ class AsciiArtItem implements MenuItemInterface
     {
         Assertion::inArray($position, [self::POSITION_CENTER, self::POSITION_RIGHT, self::POSITION_LEFT]);
         
-        $this->text      = $text;
+        $this->text = implode("\n", array_map(function (string $line) {
+            return rtrim($line, ' ');
+        }, explode("\n", $text)));
         $this->position  = $position;
         $this->alternateText = $alt;
         $this->artLength = max(array_map('mb_strlen', explode("\n", $text)));
@@ -64,23 +66,20 @@ class AsciiArtItem implements MenuItemInterface
 
             switch ($this->position) {
                 case self::POSITION_LEFT:
-                    return $row;
                     break;
                 case self::POSITION_RIGHT:
-                    $row = rtrim($row);
-                    $padding = $padding - ($this->artLength - mb_strlen($row));
+                    $padding -= ($this->artLength - $length);
                     $row = sprintf('%s%s', str_repeat(' ', $padding), $row);
                     break;
                 case self::POSITION_CENTER:
                 default:
-                    $padding = $padding - ($this->artLength - $length);
-                    $left = ceil($padding/2);
-                    $right = $padding - $left;
-                    $row = sprintf('%s%s%s', str_repeat(' ', $left), $row, str_repeat(' ', $right));
+                    $padding -= ($this->artLength - $length);
+                    $left = ceil($padding / 2);
+                    $row = sprintf('%s%s', str_repeat(' ', $left), $row);
                     break;
             }
 
-            return rtrim($row, ' ');
+            return $row;
         }, explode("\n", $this->text));
     }
 

--- a/test/MenuItem/AsciiArtItemTest.php
+++ b/test/MenuItem/AsciiArtItemTest.php
@@ -142,7 +142,7 @@ class AsciiArtItemTest extends TestCase
         self::assertSame(['my alt'], $item->getRows($menuStyle));
     }
 
-    public function testWithAsciiArtCentered() : void
+    public function testWithRealAsciiArtCenterAligned() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -174,7 +174,7 @@ ART;
         );
     }
 
-    public function testWithAsciiArtRightAligned() : void
+    public function testWithRealAsciiArtRightAligned() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -206,7 +206,7 @@ ART;
         );
     }
 
-    public function testWithRealAsciiArtCenteredWithWhiteSpaceAtTheEndOfEachLine() : void
+    public function testWithRealAsciiArtCenterAlignedWithWhiteSpaceAtTheEndOfEachLine() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 

--- a/test/MenuItem/AsciiArtItemTest.php
+++ b/test/MenuItem/AsciiArtItemTest.php
@@ -174,6 +174,38 @@ ART;
         );
     }
 
+    public function testWithAsciiArtRightAligned() : void
+    {
+        $menuStyle = $this->createMock(MenuStyle::class);
+
+        $menuStyle
+            ->expects($this->any())
+            ->method('getContentWidth')
+            ->will($this->returnValue(30));
+
+        $art = <<<ART
+        _ __ _
+       / |..| \
+       \/ || \/
+        |_''_|
+      PHP SCHOOL
+LEARNING FOR ELEPHANTS
+ART;
+
+        $item = new AsciiArtItem($art, AsciiArtItem::POSITION_RIGHT);
+        $this->assertEquals(
+            [
+                '                _ __ _',
+                '               / |..| \\',
+                '               \/ || \/',
+                "                |_''_|",
+                '              PHP SCHOOL',
+                '        LEARNING FOR ELEPHANTS'
+            ],
+            $item->getRows($menuStyle)
+        );
+    }
+
     public function testWithRealAsciiArtCenteredWithWhiteSpaceAtTheEndOfEachLine() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);

--- a/test/MenuItem/AsciiArtItemTest.php
+++ b/test/MenuItem/AsciiArtItemTest.php
@@ -91,17 +91,8 @@ class AsciiArtItemTest extends TestCase
         $item = new AsciiArtItem("//\n//", AsciiArtItem::POSITION_CENTER);
         $this->assertEquals(
             [
-                "    //    ",
-                "    //    ",
-            ],
-            $item->getRows($menuStyle)
-        );
-
-        $item = new AsciiArtItem("    //    \n//////////", AsciiArtItem::POSITION_CENTER);
-        $this->assertEquals(
-            [
-                "    //    ",
-                "//////////",
+                "    //",
+                "    //",
             ],
             $item->getRows($menuStyle)
         );
@@ -119,17 +110,8 @@ class AsciiArtItemTest extends TestCase
         $item = new AsciiArtItem("//\n//", AsciiArtItem::POSITION_CENTER);
         $this->assertEquals(
             [
-                "     //    ",
-                "     //    ",
-            ],
-            $item->getRows($menuStyle)
-        );
-
-        $item = new AsciiArtItem("    //    \n//////////", AsciiArtItem::POSITION_CENTER);
-        $this->assertEquals(
-            [
-                "     //    ",
-                " //////////",
+                "     //",
+                "     //",
             ],
             $item->getRows($menuStyle)
         );
@@ -146,7 +128,7 @@ class AsciiArtItemTest extends TestCase
         $this->assertFalse($item->showsItemExtra());
     }
 
-    public function testGetRowsReturnsStaticAltItemWhenWidthIsTooSmall()
+    public function testGetRowsReturnsStaticAltItemWhenWidthIsTooSmall() : void
     {
         $menuStyle = $this->createMock(MenuStyle::class);
 
@@ -158,5 +140,68 @@ class AsciiArtItemTest extends TestCase
         $item = new AsciiArtItem('TOO LONG. SO SO LONG.', AsciiArtItem::POSITION_CENTER, 'my alt');
         
         self::assertSame(['my alt'], $item->getRows($menuStyle));
+    }
+
+    public function testWithAsciiArtCentered() : void
+    {
+        $menuStyle = $this->createMock(MenuStyle::class);
+
+        $menuStyle
+            ->expects($this->any())
+            ->method('getContentWidth')
+            ->will($this->returnValue(30));
+
+        $art = <<<ART
+        _ __ _
+       / |..| \
+       \/ || \/
+        |_''_|
+      PHP SCHOOL
+LEARNING FOR ELEPHANTS
+ART;
+
+        $item = new AsciiArtItem($art, AsciiArtItem::POSITION_CENTER);
+        $this->assertEquals(
+            [
+                '            _ __ _',
+                '           / |..| \\',
+                '           \/ || \/',
+                "            |_''_|",
+                '          PHP SCHOOL',
+                '    LEARNING FOR ELEPHANTS'
+            ],
+            $item->getRows($menuStyle)
+        );
+    }
+
+    public function testWithRealAsciiArtCenteredWithWhiteSpaceAtTheEndOfEachLine() : void
+    {
+        $menuStyle = $this->createMock(MenuStyle::class);
+
+        $menuStyle
+            ->expects($this->any())
+            ->method('getContentWidth')
+            ->will($this->returnValue(30));
+        
+        $art = <<<ART
+        _ __ _        
+       / |..| \       
+       \/ || \/       
+        |_''_|        
+      PHP SCHOOL      
+LEARNING FOR ELEPHANTS
+ART;
+        $item = new AsciiArtItem($art, AsciiArtItem::POSITION_CENTER);
+        $this->assertEquals(
+            [
+                '            _ __ _',
+                '           / |..| \\',
+                '           \/ || \/',
+                "            |_''_|",
+                '          PHP SCHOOL',
+                '    LEARNING FOR ELEPHANTS'
+            ],
+            $item->getRows($menuStyle)
+        );
     }
 }


### PR DESCRIPTION
* Extracted tests for whitespace at the end of ascii art lines to own test
* Added test for actual ascii art
* Strip whitespace from each line of the given test
* Remove redundant `trim` and `mb_strlen` calls
* Remove right padding - (I'm not really sure what that is for?)

@Lynesth could you take a look at this please