### PR TITLE
Enable cursor when exiting terminal - closes #90

### DIFF
--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -120,6 +120,7 @@ class CliMenu
     protected function tearDownTerminal() : void
     {
         $this->terminal->restoreOriginalConfiguration();
+        $this->terminal->enableCursor();
     }
 
     private function assertTerminalIsValidTTY() : void


### PR DESCRIPTION
It should be enabled here, because we specifically disabled it. I don't think it is up to `UnixTerminal` to handle this as it doesn't specifically disable it.