### PR TITLE
Fix right padding when row too long

### DIFF
--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -376,6 +376,13 @@ class CliMenu
         }
 
         return array_map(function ($row) use ($invertedColour, $notInvertedColour, $borderColour) {
+
+            $rightPadding = $this->style->getRightHandPadding(mb_strlen(s::stripAnsiEscapeSequence($row)));
+            
+            if ($rightPadding < 0) {
+                $rightPadding = 0;
+            }
+        
             return sprintf(
                 "%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
                 str_repeat(' ', $this->style->getMargin()),
@@ -385,7 +392,7 @@ class CliMenu
                 $invertedColour,
                 str_repeat(' ', $this->style->getPadding()),
                 $row,
-                str_repeat(' ', $this->style->getRightHandPadding(mb_strlen(s::stripAnsiEscapeSequence($row)))),
+                str_repeat(' ', $rightPadding),
                 $notInvertedColour,
                 $borderColour,
                 str_repeat(' ', $this->style->getBorderRightWidth()),

--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -376,13 +376,6 @@ class CliMenu
         }
 
         return array_map(function ($row) use ($invertedColour, $notInvertedColour, $borderColour) {
-
-            $rightPadding = $this->style->getRightHandPadding(mb_strlen(s::stripAnsiEscapeSequence($row)));
-            
-            if ($rightPadding < 0) {
-                $rightPadding = 0;
-            }
-        
             return sprintf(
                 "%s%s%s%s%s%s%s%s%s%s%s%s%s\n",
                 str_repeat(' ', $this->style->getMargin()),
@@ -392,7 +385,7 @@ class CliMenu
                 $invertedColour,
                 str_repeat(' ', $this->style->getPadding()),
                 $row,
-                str_repeat(' ', $rightPadding),
+                str_repeat(' ', $this->style->getRightHandPadding(mb_strlen(s::stripAnsiEscapeSequence($row)))),
                 $notInvertedColour,
                 $borderColour,
                 str_repeat(' ', $this->style->getBorderRightWidth()),

--- a/src/MenuStyle.php
+++ b/src/MenuStyle.php
@@ -409,7 +409,13 @@ class MenuStyle
      */
     public function getRightHandPadding(int $contentLength) : int
     {
-        return $this->getContentWidth() - $contentLength + $this->getPadding();
+        $rightPadding = $this->getContentWidth() - $contentLength + $this->getPadding();
+
+        if ($rightPadding < 0) {
+            $rightPadding = 0;
+        }
+
+        return $rightPadding;
     }
 
     public function getSelectedMarker() : string

--- a/test/MenuStyleTest.php
+++ b/test/MenuStyleTest.php
@@ -301,6 +301,35 @@ class MenuStyleTest extends TestCase
         static::assertSame(241, $style->getRightHandPadding(50));
     }
 
+    public function testRightHandPaddingReturnsZeroWhenContentLengthTooLong() : void
+    {
+        $style = $this->getMenuStyle();
+        $style->setPadding(0);
+        $style->setMargin(0);
+        $style->setBorder(0);
+
+        $style->setWidth(100);
+        
+        self::assertEquals(0, $style->getRightHandPadding(100));
+        self::assertEquals(0, $style->getRightHandPadding(150));
+    }
+
+    public function testRightHandPaddingReturnsZeroWhenContentLengthTooLongBecauseOfBorder() : void
+    {
+        $style = $this->getMenuStyle();
+        $style->setPadding(10);
+        $style->setMargin(0);
+        $style->setBorder(10);
+
+        $style->setWidth(100);
+
+        self::assertEquals(11, $style->getRightHandPadding(59));
+        self::assertEquals(10, $style->getRightHandPadding(60));
+        self::assertEquals(0, $style->getRightHandPadding(70));
+        self::assertEquals(0, $style->getRightHandPadding(71));
+        self::assertEquals(0, $style->getRightHandPadding(100));
+    }
+
     public function testMargin() : void
     {
         $style = $this->getMenuStyle();


### PR DESCRIPTION
This PR fixes the negative right padding when the row is too long. We have a few options to improve this:

1. Leave it as it is now where the text goes off the edge:
<img width="661" alt="screen shot 2018-05-07 at 19 45 52" src="https://user-images.githubusercontent.com/2817002/39716002-5208a1ac-522f-11e8-8239-14e55a584c29.png">

2. split the row and put it on a new line


3. throw an exception

What does everyone think? @Lynesth @mikeerickson 