### PR TITLE
Allow markers longer than 1 character

### DIFF
--- a/src/MenuStyle.php
+++ b/src/MenuStyle.php
@@ -517,7 +517,7 @@ class MenuStyle
 
     public function setSelectedMarker(string $marker) : self
     {
-        $this->selectedMarker = mb_substr($marker, 0, 1);
+        $this->selectedMarker = $marker;
 
         return $this;
     }
@@ -529,7 +529,7 @@ class MenuStyle
 
     public function setUnselectedMarker(string $marker) : self
     {
-        $this->unselectedMarker = mb_substr($marker, 0, 1);
+        $this->unselectedMarker = $marker;
 
         return $this;
     }


### PR DESCRIPTION
Allows more customization. Thought about at least trimming it but then I thought it would allow this king of thing:
![2018-05-14_23-27-28](https://user-images.githubusercontent.com/5318258/39997391-8ca6d442-57ce-11e8-978a-7c41251bf71c.gif)


@mikeymike any reason it was limited to 1 character in the first place ?