### PR TITLE
adds methods for disabling the default VIM mappings and setting your own

### DIFF
--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -201,6 +201,22 @@ class CliMenu
     }
 
     /**
+     * Disables the built-in VIM control mappings
+     */
+    public function disableDefaultControlMappings() : void
+    {
+        $this->defaultControlMappings = [];
+    }
+
+    /**
+     * Set default control mappings
+     */
+    public function setDefaultControlMappings(array $defaultControlMappings) : void
+    {
+        $this->defaultControlMappings = $defaultControlMappings;
+    }    
+
+    /**
      * Adds a custom control mapping
      */
     public function addCustomControlMapping(string $input, callable $callable) : void


### PR DESCRIPTION
example usage:

```
        $menu = (new CliMenuBuilder)
        ->addItem('Print A', function () { echo 'A'; })
        ->build();

        $menu->disableDefaultControlMappings();

        $menu->open();
```

```
        $menu = (new CliMenuBuilder)
        ->addItem('Print A', function () { echo 'A'; })
        ->build();

        $defaultControlMappings = [
            'a' => InputCharacter::LEFT,
            's' => InputCharacter::DOWN,
            'w' => InputCharacter::UP,
            'd' => InputCharacter::RIGHT,
        ];

        $menu->setDefaultControlMappings($defaultControlMappings);

        $menu->open();
```
