### PR TITLE
Allow ESC key to "cancel" editing an input

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php" : ">=7.1",
         "beberlei/assert": "^2.4 | ^3",
-        "php-school/terminal": "dev-master",
+        "php-school/terminal": "^0.2",
         "ext-posix": "*"
     },
     "autoload" : {

--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -214,7 +214,7 @@ class CliMenu
     public function setDefaultControlMappings(array $defaultControlMappings) : void
     {
         $this->defaultControlMappings = $defaultControlMappings;
-    }    
+    }
 
     /**
      * Adds a custom control mapping

--- a/src/Input/InputIO.php
+++ b/src/Input/InputIO.php
@@ -40,6 +40,8 @@ class InputIO
 
         $inputValue = $input->getPlaceholderText();
         $havePlaceHolderValue = !empty($inputValue);
+        
+        $originalValue = $inputValue;
 
         $reader = new NonCanonicalReader($this->terminal);
 
@@ -59,6 +61,9 @@ class InputIO
 
             if ($char->isHandledControl()) {
                 switch ($char->getControl()) {
+                    case InputCharacter::ESC:
+                        $this->parentMenu->redraw();
+                        return new InputResult($originalValue);
                     case InputCharacter::ENTER:
                         if ($input->validate($inputValue)) {
                             $this->parentMenu->redraw();


### PR DESCRIPTION
It will simply return the initial value (empty string or the placeholder text) when the user presses the ESC key, even if the text was modified.