### PR TITLE
Make defaultControlMappings static

### DIFF
--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -63,7 +63,7 @@ class CliMenu
     /**
      * @var array
      */
-    protected $defaultControlMappings = [
+    protected static $defaultControlMappings = [
         '^P' => InputCharacter::UP,
         'k'  => InputCharacter::UP,
         '^K' => InputCharacter::DOWN,
@@ -202,18 +202,19 @@ class CliMenu
 
     /**
      * Disables the built-in VIM control mappings
+     * Does not remove Arrow keys, Enter, etc used for navigation
      */
-    public function disableDefaultControlMappings() : void
+    public static function disableDefaultControlMappings() : void
     {
-        $this->defaultControlMappings = [];
+        self::$defaultControlMappings = [];
     }
 
     /**
      * Set default control mappings
      */
-    public function setDefaultControlMappings(array $defaultControlMappings) : void
+    public static function setDefaultControlMappings(array $defaultControlMappings) : void
     {
-        $this->defaultControlMappings = $defaultControlMappings;
+        self::$defaultControlMappings = $defaultControlMappings;
     }
 
     /**
@@ -221,7 +222,7 @@ class CliMenu
      */
     public function addCustomControlMapping(string $input, callable $callable) : void
     {
-        if (isset($this->defaultControlMappings[$input]) || isset($this->customControlMappings[$input])) {
+        if (isset(self::$defaultControlMappings[$input]) || isset($this->customControlMappings[$input])) {
             throw new \InvalidArgumentException('Cannot rebind this input');
         }
 
@@ -258,7 +259,7 @@ class CliMenu
         $this->draw();
 
         $reader = new NonCanonicalReader($this->terminal);
-        $reader->addControlMappings($this->defaultControlMappings);
+        $reader->addControlMappings(self::$defaultControlMappings);
 
         while ($this->isOpen()) {
             $char = $reader->readCharacter();


### PR DESCRIPTION
I guess that's more what we expect from the whole thing now that we can modify it.
Made those 2 new functions static too because I think it makes more sense.

Snippet:

```php
CliMenu::disableDefaultControlMappings()

$menu = (new CliMenuBuilder) // Will be disabled for this menu
    ->setTitle('Main menu')
    ->addSubMenu('Options', function (CliMenuBuilder $b) { // Will also be disabled for submenus
        $b->setTitle('Submenu')
            ->addStaticItem('Some text')
            ->addLineBreak('-');
    })
    ->build();
```