### PR TITLE
Php 7.4 support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 vendor/
 .idea
 /composer.lock
+/.phpunit.result.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 php:
   - 7.2
   - 7.3
-  - 7.4snapshot
+  - 7.4
 
 install:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ cache:
     - $HOME/.composer/cache/files
 
 php:
-  - 7.1
   - 7.2
   - 7.3
+  - 7.4
 
 install:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ cache:
 php:
   - 7.2
   - 7.3
-  - 7.4
+  - 7.4snapshot
 
 install:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
         }
     ],
     "require-dev": {
-        "phpunit/phpunit": "^7.1",
+        "phpunit/phpunit": "^8.0",
         "squizlabs/php_codesniffer": "^3.2",
         "phpstan/phpstan": "^0.11"
     },

--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -132,6 +132,11 @@ class CliMenu
         $this->title = $title;
     }
 
+    public function getTitle() : ?string
+    {
+        return $this->title;
+    }
+
     public function setParent(CliMenu $parent) : void
     {
         $this->parent = $parent;
@@ -226,6 +231,11 @@ class CliMenu
         }
 
         $this->customControlMappings[$input] = $callable;
+    }
+
+    public function getCustomControlMappings() : array
+    {
+        return $this->customControlMappings;
     }
 
     /**

--- a/src/MenuItem/AsciiArtItem.php
+++ b/src/MenuItem/AsciiArtItem.php
@@ -128,6 +128,16 @@ class AsciiArtItem implements MenuItemInterface
         return $this->artLength;
     }
 
+    public function getPosition() : string
+    {
+        return $this->position;
+    }
+
+    public function getAlternateText() : string
+    {
+        return $this->alternateText;
+    }
+
     /**
      * Whether or not the menu item is showing the menustyle extra value
      */

--- a/src/MenuItem/LineBreakItem.php
+++ b/src/MenuItem/LineBreakItem.php
@@ -80,6 +80,11 @@ class LineBreakItem implements MenuItemInterface
         return false;
     }
 
+    public function getLines() : int
+    {
+        return $this->lines;
+    }
+
     /**
      * Enable showing item extra
      */

--- a/src/MenuItem/SplitItem.php
+++ b/src/MenuItem/SplitItem.php
@@ -52,6 +52,11 @@ class SplitItem implements MenuItemInterface
         $this->gutter = $gutter;
     }
 
+    public function getGutter() : int
+    {
+        return $this->gutter;
+    }
+
     public function addItem(MenuItemInterface $item) : self
     {
         foreach (self::$blacklistedItems as $bl) {

--- a/test/Builder/CliMenuBuilderTest.php
+++ b/test/Builder/CliMenuBuilderTest.php
@@ -11,7 +11,6 @@ use PhpSchool\CliMenu\MenuItem\SelectableItem;
 use PhpSchool\CliMenu\MenuItem\StaticItem;
 use PhpSchool\Terminal\Terminal;
 use PHPUnit\Framework\TestCase;
-use RuntimeException;
 
 /**
  * @author Aydin Hassan <aydin@hotmail.co.uk>
@@ -69,17 +68,18 @@ class CliMenuBuilderTest extends TestCase
         $builder->setTitleSeparator('-');
 
         $menu = $builder->build();
+        $style = $menu->getStyle();
 
-        $this->checkStyleVariable($menu, 'bg', 'red');
-        $this->checkStyleVariable($menu, 'fg', 'red');
-        $this->checkStyleVariable($menu, 'width', 40);
-        $this->checkStyleVariable($menu, 'paddingTopBottom', 4);
-        $this->checkStyleVariable($menu, 'paddingLeftRight', 1);
-        $this->checkStyleVariable($menu, 'margin', 4);
-        $this->checkStyleVariable($menu, 'unselectedMarker', '>');
-        $this->checkStyleVariable($menu, 'selectedMarker', 'x');
-        $this->checkStyleVariable($menu, 'itemExtra', '*');
-        $this->checkStyleVariable($menu, 'titleSeparator', '-');
+        self::assertEquals('red', $style->getBg());
+        self::assertEquals('red', $style->getFg());
+        self::assertEquals(40, $style->getWidth());
+        self::assertEquals(4, $style->getPaddingTopBottom());
+        self::assertEquals(1, $style->getPaddingLeftRight());
+        self::assertEquals(4, $style->getMargin());
+        self::assertEquals('>', $style->getUnselectedMarker());
+        self::assertEquals('x', $style->getSelectedMarker());
+        self::assertEquals('*', $style->getItemExtra());
+        self::assertEquals('-', $style->getTitleSeparator());
     }
 
     public function testSetBorderShorthandFunction() : void
@@ -90,85 +90,93 @@ class CliMenuBuilderTest extends TestCase
             ->method('getWidth')
             ->will($this->returnValue(200));
 
-        $menu = (new CliMenuBuilder($terminal))
+        $style = (new CliMenuBuilder($terminal))
             ->setBorder(2)
-            ->build();
-        
-        $this->checkStyleVariable($menu, 'borderTopWidth', 2);
-        $this->checkStyleVariable($menu, 'borderRightWidth', 2);
-        $this->checkStyleVariable($menu, 'borderBottomWidth', 2);
-        $this->checkStyleVariable($menu, 'borderLeftWidth', 2);
-        $this->checkStyleVariable($menu, 'borderColour', 'white');
+            ->build()
+            ->getStyle();
 
-        $menu = (new CliMenuBuilder($terminal))
+        self::assertEquals(2, $style->getBorderTopWidth());
+        self::assertEquals(2, $style->getBorderRightWidth());
+        self::assertEquals(2, $style->getBorderBottomWidth());
+        self::assertEquals(2, $style->getBorderLeftWidth());
+        self::assertEquals('white', $style->getBorderColour());
+
+        $style = (new CliMenuBuilder($terminal))
             ->setBorder(2, 4)
-            ->build();
-        
-        $this->checkStyleVariable($menu, 'borderTopWidth', 2);
-        $this->checkStyleVariable($menu, 'borderRightWidth', 4);
-        $this->checkStyleVariable($menu, 'borderBottomWidth', 2);
-        $this->checkStyleVariable($menu, 'borderLeftWidth', 4);
-        $this->checkStyleVariable($menu, 'borderColour', 'white');
+            ->build()
+            ->getStyle();
 
-        $menu = (new CliMenuBuilder($terminal))
+        self::assertEquals(2, $style->getBorderTopWidth());
+        self::assertEquals(4, $style->getBorderRightWidth());
+        self::assertEquals(2, $style->getBorderBottomWidth());
+        self::assertEquals(4, $style->getBorderLeftWidth());
+        self::assertEquals('white', $style->getBorderColour());
+
+        $style = (new CliMenuBuilder($terminal))
             ->setBorder(2, 4, 6)
-            ->build();
-        
-        $this->checkStyleVariable($menu, 'borderTopWidth', 2);
-        $this->checkStyleVariable($menu, 'borderRightWidth', 4);
-        $this->checkStyleVariable($menu, 'borderBottomWidth', 6);
-        $this->checkStyleVariable($menu, 'borderLeftWidth', 4);
-        $this->checkStyleVariable($menu, 'borderColour', 'white');
+            ->build()
+            ->getStyle();
 
-        $menu = (new CliMenuBuilder($terminal))
+        self::assertEquals(2, $style->getBorderTopWidth());
+        self::assertEquals(4, $style->getBorderRightWidth());
+        self::assertEquals(6, $style->getBorderBottomWidth());
+        self::assertEquals(4, $style->getBorderLeftWidth());
+        self::assertEquals('white', $style->getBorderColour());
+
+        $style = (new CliMenuBuilder($terminal))
             ->setBorder(2, 4, 6, 8)
-            ->build();
-        
-        $this->checkStyleVariable($menu, 'borderTopWidth', 2);
-        $this->checkStyleVariable($menu, 'borderRightWidth', 4);
-        $this->checkStyleVariable($menu, 'borderBottomWidth', 6);
-        $this->checkStyleVariable($menu, 'borderLeftWidth', 8);
-        $this->checkStyleVariable($menu, 'borderColour', 'white');
+            ->build()
+            ->getStyle();
 
-        $menu = (new CliMenuBuilder($terminal))
+        self::assertEquals(2, $style->getBorderTopWidth());
+        self::assertEquals(4, $style->getBorderRightWidth());
+        self::assertEquals(6, $style->getBorderBottomWidth());
+        self::assertEquals(8, $style->getBorderLeftWidth());
+        self::assertEquals('white', $style->getBorderColour());
+
+        $style = (new CliMenuBuilder($terminal))
             ->setBorder(2, 4, 6, 8, 'green')
-            ->build();
-        
-        $this->checkStyleVariable($menu, 'borderTopWidth', 2);
-        $this->checkStyleVariable($menu, 'borderRightWidth', 4);
-        $this->checkStyleVariable($menu, 'borderBottomWidth', 6);
-        $this->checkStyleVariable($menu, 'borderLeftWidth', 8);
-        $this->checkStyleVariable($menu, 'borderColour', 'green');
+            ->build()
+            ->getStyle();
 
-        $menu = (new CliMenuBuilder($terminal))
+        self::assertEquals(2, $style->getBorderTopWidth());
+        self::assertEquals(4, $style->getBorderRightWidth());
+        self::assertEquals(6, $style->getBorderBottomWidth());
+        self::assertEquals(8, $style->getBorderLeftWidth());
+        self::assertEquals('green', $style->getBorderColour());
+
+        $style = (new CliMenuBuilder($terminal))
             ->setBorder(2, 4, 6, 'green')
-            ->build();
-        
-        $this->checkStyleVariable($menu, 'borderTopWidth', 2);
-        $this->checkStyleVariable($menu, 'borderRightWidth', 4);
-        $this->checkStyleVariable($menu, 'borderBottomWidth', 6);
-        $this->checkStyleVariable($menu, 'borderLeftWidth', 4);
-        $this->checkStyleVariable($menu, 'borderColour', 'green');
+            ->build()
+            ->getStyle();
 
-        $menu = (new CliMenuBuilder($terminal))
+        self::assertEquals(2, $style->getBorderTopWidth());
+        self::assertEquals(4, $style->getBorderRightWidth());
+        self::assertEquals(6, $style->getBorderBottomWidth());
+        self::assertEquals(4, $style->getBorderLeftWidth());
+        self::assertEquals('green', $style->getBorderColour());
+
+        $style = (new CliMenuBuilder($terminal))
             ->setBorder(2, 4, 'green')
-            ->build();
-        
-        $this->checkStyleVariable($menu, 'borderTopWidth', 2);
-        $this->checkStyleVariable($menu, 'borderRightWidth', 4);
-        $this->checkStyleVariable($menu, 'borderBottomWidth', 2);
-        $this->checkStyleVariable($menu, 'borderLeftWidth', 4);
-        $this->checkStyleVariable($menu, 'borderColour', 'green');
+            ->build()
+            ->getStyle();
 
-        $menu = (new CliMenuBuilder($terminal))
+        self::assertEquals(2, $style->getBorderTopWidth());
+        self::assertEquals(4, $style->getBorderRightWidth());
+        self::assertEquals(2, $style->getBorderBottomWidth());
+        self::assertEquals(4, $style->getBorderLeftWidth());
+        self::assertEquals('green', $style->getBorderColour());
+
+        $style = (new CliMenuBuilder($terminal))
             ->setBorder(2, 'green')
-            ->build();
-        
-        $this->checkStyleVariable($menu, 'borderTopWidth', 2);
-        $this->checkStyleVariable($menu, 'borderRightWidth', 2);
-        $this->checkStyleVariable($menu, 'borderBottomWidth', 2);
-        $this->checkStyleVariable($menu, 'borderLeftWidth', 2);
-        $this->checkStyleVariable($menu, 'borderColour', 'green');
+            ->build()
+            ->getStyle();
+
+        self::assertEquals(2, $style->getBorderTopWidth());
+        self::assertEquals(2, $style->getBorderRightWidth());
+        self::assertEquals(2, $style->getBorderBottomWidth());
+        self::assertEquals(2, $style->getBorderLeftWidth());
+        self::assertEquals('green', $style->getBorderColour());
     }
 
     public function testSetBorderTopWidth() : void
@@ -232,10 +240,11 @@ class CliMenuBuilderTest extends TestCase
         $builder = new CliMenuBuilder($terminal);
         $builder->setBackgroundColour(16, 'white');
         $builder->setForegroundColour(206, 'red');
-        $menu = $builder->build();
+        $style = $builder->build()
+            ->getStyle();
 
-        $this->checkStyleVariable($menu, 'bg', 16);
-        $this->checkStyleVariable($menu, 'fg', 206);
+        self::assertEquals(16, $style->getBg());
+        self::assertEquals(206, $style->getFg());
 
         $terminal = static::createMock(Terminal::class);
         $terminal
@@ -246,10 +255,11 @@ class CliMenuBuilderTest extends TestCase
         $builder = new CliMenuBuilder($terminal);
         $builder->setBackgroundColour(16, 'white');
         $builder->setForegroundColour(206, 'red');
-        $menu = $builder->build();
+        $style = $builder->build()
+            ->getStyle();
 
-        $this->checkStyleVariable($menu, 'bg', 'white');
-        $this->checkStyleVariable($menu, 'fg', 'red');
+        self::assertEquals('white', $style->getBg());
+        self::assertEquals('red', $style->getFg());
     }
 
     public function testSetFgThrowsExceptionWhenColourCodeIsNotInRange() : void
@@ -288,8 +298,8 @@ class CliMenuBuilderTest extends TestCase
         $builder->disableDefaultItems();
         
         $menu = $builder->build();
-            
-        $this->checkVariable($menu, 'items', []);
+
+        self::assertEquals([], $menu->getItems());
     }
 
     public function testSetTitle() : void
@@ -299,7 +309,7 @@ class CliMenuBuilderTest extends TestCase
         
         $menu = $builder->build();
 
-        $this->checkVariable($menu, 'title', 'title');
+        self::assertEquals('title', $menu->getTitle());
     }
 
     public function testAddItem() : void
@@ -782,11 +792,15 @@ class CliMenuBuilderTest extends TestCase
 
     private function checkMenuItems(CliMenu $menu, array $expected) : void
     {
-        $this->checkItems($this->readAttribute($menu, 'items'), $expected);
+        $this->checkItems($menu->getItems(), $expected);
     }
 
     private function checkItems(array $actualItems, array $expected) : void
     {
+        $propMap = [
+            'breakChar' => 'getText',
+        ];
+
         self::assertCount(count($expected), $actualItems);
 
         foreach ($expected as $expectedItem) {
@@ -796,21 +810,15 @@ class CliMenuBuilderTest extends TestCase
             unset($expectedItem['class']);
 
             foreach ($expectedItem as $property => $value) {
-                self::assertEquals($this->readAttribute($actualItem, $property), $value);
+
+                if (isset($propMap[$property])) {
+                    $getter = $propMap[$property];
+                } else {
+                    $getter = 'get'. ucfirst($property);
+                }
+
+                self::assertEquals($actualItem->{$getter}(), $value);
             }
         }
-    }
-
-    
-    private function checkVariable(CliMenu $menu, string $property, $expected) : void
-    {
-        $actual = $this->readAttribute($menu, $property);
-        self::assertEquals($expected, $actual);
-    }
-
-    private function checkStyleVariable(CliMenu $menu, string $property, $expected) : void
-    {
-        $style = $this->readAttribute($menu, 'style');
-        self::assertEquals($this->readAttribute($style, $property), $expected);
     }
 }

--- a/test/Builder/CliMenuBuilderTest.php
+++ b/test/Builder/CliMenuBuilderTest.php
@@ -810,7 +810,6 @@ class CliMenuBuilderTest extends TestCase
             unset($expectedItem['class']);
 
             foreach ($expectedItem as $property => $value) {
-
                 if (isset($propMap[$property])) {
                     $getter = $propMap[$property];
                 } else {

--- a/test/Builder/SplitItemBuilderTest.php
+++ b/test/Builder/SplitItemBuilderTest.php
@@ -90,7 +90,7 @@ class SplitItemBuilderTest extends TestCase
         $builder->setGutter(4);
 
         $item = $builder->build();
-        self::assertEquals(4, self::readAttribute($item, 'gutter'));
+        self::assertEquals(4, $item->getGutter());
     }
 
     public function testAddSubMenuWithClosureBinding() : void
@@ -134,7 +134,7 @@ class SplitItemBuilderTest extends TestCase
             unset($expectedItem['class']);
 
             foreach ($expectedItem as $property => $value) {
-                self::assertEquals($this->readAttribute($actualItem, $property), $value);
+                self::assertEquals($actualItem->{'get'. ucfirst($property)}(), $value);
             }
         }
     }

--- a/test/CliMenuTest.php
+++ b/test/CliMenuTest.php
@@ -29,7 +29,7 @@ class CliMenuTest extends TestCase
      */
     private $output;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->output = new BufferedOutput;
         $this->terminal = $this->createMock(Terminal::class);
@@ -671,10 +671,10 @@ class CliMenuTest extends TestCase
 
         $menu = new CliMenu('PHP School FTW', [], $this->terminal);
         $menu->addCustomControlMapping('c', $action);
-        self::assertSame(['c' => $action], $this->readAttribute($menu, 'customControlMappings'));
+        self::assertSame(['c' => $action], $menu->getCustomControlMappings());
         
         $menu->removeCustomControlMapping('c');
-        self::assertSame([], $this->readAttribute($menu, 'customControlMappings'));
+        self::assertSame([], $menu->getCustomControlMappings());
     }
 
     public function testSplitItemWithNoSelectableItemsScrollingVertically() : void
@@ -847,7 +847,11 @@ class CliMenuTest extends TestCase
         $menu = new CliMenu('PHP School FTW', [], $this->terminal);
         $menu->addItem(new StaticItem('No Selectable'));
 
-        self::assertNull(self::readAttribute($menu, 'selectedItem'));
+        try {
+            $menu->getSelectedItem();
+            $this->fail('Exception not thrown');
+        } catch (\RuntimeException $e) {
+        }
 
         $menu->addItem($item = new SelectableItem('Selectable', function () {
         }));
@@ -860,7 +864,11 @@ class CliMenuTest extends TestCase
         $menu = new CliMenu('PHP School FTW', [], $this->terminal);
         $menu->addItem(new StaticItem('No Selectable'));
 
-        self::assertNull(self::readAttribute($menu, 'selectedItem'));
+        try {
+            $menu->getSelectedItem();
+            $this->fail('Exception not thrown');
+        } catch (\RuntimeException $e) {
+        }
 
         $menu->addItems([$item = new SelectableItem('Selectable', function () {
         })]);
@@ -894,7 +902,11 @@ class CliMenuTest extends TestCase
 
         $menu->removeItem($item);
 
-        self::assertNull(self::readAttribute($menu, 'selectedItem'));
+        try {
+            $menu->getSelectedItem();
+            $this->fail('Exception not thrown');
+        } catch (\RuntimeException $e) {
+        }
 
         $menu = new CliMenu('PHP School FTW', [], $this->terminal);
         $menu->addItem(new StaticItem('No Selectable'));

--- a/test/Dialogue/ConfirmTest.php
+++ b/test/Dialogue/ConfirmTest.php
@@ -24,7 +24,7 @@ class ConfirmTest extends TestCase
      */
     private $output;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->output = new BufferedOutput;
         $this->terminal = $this->createMock(Terminal::class);

--- a/test/Dialogue/FlashTest.php
+++ b/test/Dialogue/FlashTest.php
@@ -24,7 +24,7 @@ class FlashTest extends TestCase
      */
     private $output;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->output = new BufferedOutput;
         $this->terminal = $this->createMock(Terminal::class);

--- a/test/Input/InputIOTest.php
+++ b/test/Input/InputIOTest.php
@@ -41,7 +41,7 @@ class InputIOTest extends TestCase
      */
     private $inputIO;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->terminal = $this->createMock(Terminal::class);
         $this->output   = new BufferedOutput;

--- a/test/Input/NumberTest.php
+++ b/test/Input/NumberTest.php
@@ -29,7 +29,7 @@ class NumberTest extends TestCase
      */
     private $input;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->terminal = $this->createMock(Terminal::class);
         $menu           = $this->createMock(CliMenu::class);

--- a/test/Input/PasswordTest.php
+++ b/test/Input/PasswordTest.php
@@ -29,7 +29,7 @@ class PasswordTest extends TestCase
      */
     private $input;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->terminal = $this->createMock(Terminal::class);
         $menu           = $this->createMock(CliMenu::class);

--- a/test/Input/TextTest.php
+++ b/test/Input/TextTest.php
@@ -29,7 +29,7 @@ class TextTest extends TestCase
      */
     private $input;
 
-    public function setUp()
+    public function setUp() : void
     {
         $this->terminal = $this->createMock(Terminal::class);
         $menu           = $this->createMock(CliMenu::class);

--- a/test/MenuItem/MenuMenuItemTest.php
+++ b/test/MenuItem/MenuMenuItemTest.php
@@ -28,7 +28,7 @@ class MenuMenuItemTest extends TestCase
         $item = new MenuMenuItem('Item', $subMenu);
         
         $action = $item->getSelectAction();
-        $this->assertInternalType('callable', $action);
+        $this->assertIsCallable($action);
     }
 
     public function testShowsItemExtra() : void


### PR DESCRIPTION
* Upgrade PHPUnit and fix some deprecations. PHPUnit 7 does not support PHP 7.4. I've had to expose a few properties because of deprecations regarding methods for accessing private properties in PHPUnit. Probably for the best.
* Drop 7.1 testing from travis and add 7.4. We can still support 7.1 but we can't test on travis both 7.1 and 7.4 with the same version of PHPunit.