### PR TITLE
Auto-toggle CheckableItem

### DIFF
--- a/README.md
+++ b/README.md
@@ -555,9 +555,7 @@ use PhpSchool\CliMenu\Builder\CliMenuBuilder;
 use PhpSchool\CliMenu\CliMenu;
 
 $callable = function (CliMenu $menu) {
-    $item = $menu->getSelectedItem();
-    $item->toggle();
-    $menu->redraw();
+    echo $menu->getSelectedItem()->getText();
 };
 
 $menu = (new CliMenuBuilder)

--- a/examples/checkable-item.php
+++ b/examples/checkable-item.php
@@ -2,17 +2,11 @@
 
 use PhpSchool\CliMenu\CliMenu;
 use PhpSchool\CliMenu\Builder\CliMenuBuilder;
-use PhpSchool\CliMenu\MenuItem\CheckableItem;
 
 require_once(__DIR__ . '/../vendor/autoload.php');
 
 $itemCallable = function (CliMenu $menu) {
-    /** @var CheckableItem $item */
-    $item = $menu->getSelectedItem();
-
-    $item->toggle();
-
-    $menu->redraw();
+    echo $menu->getSelectedItem()->getText();
 };
 
 $menu = (new CliMenuBuilder)

--- a/src/MenuItem/CheckableItem.php
+++ b/src/MenuItem/CheckableItem.php
@@ -2,6 +2,7 @@
 
 namespace PhpSchool\CliMenu\MenuItem;
 
+use PhpSchool\CliMenu\CliMenu;
 use PhpSchool\CliMenu\MenuStyle;
 use PhpSchool\CliMenu\Util\StringUtil;
 
@@ -49,7 +50,12 @@ class CheckableItem implements MenuItemInterface
      */
     public function getSelectAction() : ?callable
     {
-        return $this->selectAction;
+        return function (CliMenu $cliMenu) {
+            $this->toggle();
+            $cliMenu->redraw();
+
+            return ($this->selectAction)($cliMenu);
+        };
     }
 
     /**

--- a/test/MenuItem/CheckableItemTest.php
+++ b/test/MenuItem/CheckableItemTest.php
@@ -2,6 +2,7 @@
 
 namespace PhpSchool\CliMenuTest\MenuItem;
 
+use PhpSchool\CliMenu\CliMenu;
 use PhpSchool\CliMenu\MenuItem\CheckableItem;
 use PhpSchool\CliMenu\MenuStyle;
 use PhpSchool\Terminal\Terminal;
@@ -14,6 +15,20 @@ class CheckableItemTest extends TestCase
         $item = new CheckableItem('Item', function () {
         });
         $this->assertTrue($item->canSelect());
+    }
+
+    public function testGetSelectAction() : void
+    {
+        $callable = function () {
+            return 'callable is called';
+        };
+        $item = new CheckableItem('Item', $callable);
+
+        $cliMenu = $this->getMockBuilder(CLiMenu::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+
+        $this->assertSame($callable(), $item->getSelectAction()($cliMenu));
     }
 
     public function testShowsItemExtra() : void

--- a/test/MenuItem/CheckableItemTest.php
+++ b/test/MenuItem/CheckableItemTest.php
@@ -16,14 +16,6 @@ class CheckableItemTest extends TestCase
         $this->assertTrue($item->canSelect());
     }
 
-    public function testGetSelectAction() : void
-    {
-        $callable = function () {
-        };
-        $item = new CheckableItem('Item', $callable);
-        $this->assertSame($callable, $item->getSelectAction());
-    }
-
     public function testShowsItemExtra() : void
     {
         $item = new CheckableItem('Item', function () {


### PR DESCRIPTION
Per [this comment](https://github.com/php-school/cli-menu/issues/188#issuecomment-566478740) it makes sense for a CheckboxItem to auto-toggle itself (either on or off) vs forcing developer to implement this themselves.

`CheckableItem::getSelectAction()` returns a `callable` within a `callable`. The outer `callable` does the auto-toggling, the inner `callable` is the user-defined code.

The `CheckableItemTest::testGetSelectAction()` reflects this stacking.