### PR TITLE
Propagates styles from bottom up

### DIFF
--- a/src/Builder/CliMenuBuilder.php
+++ b/src/Builder/CliMenuBuilder.php
@@ -188,12 +188,6 @@ class CliMenuBuilder
         $menu = $builder->build();
         $menu->setParent($this->menu);
         
-        //we apply the parent theme if nothing was changed
-        //if no styles were changed in this sub-menu
-        if (!$menu->getStyle()->hasChangedFromDefaults()) {
-            $menu->setStyle($this->menu->getStyle());
-        }
-
         $this->menu->addItem($item = new MenuMenuItem(
             $text,
             $menu,
@@ -209,12 +203,6 @@ class CliMenuBuilder
     {
         $menu = $builder->build();
         $menu->setParent($this->menu);
-
-        //we apply the parent theme if nothing was changed
-        //if no styles were changed in this sub-menu
-        if (!$menu->getStyle()->hasChangedFromDefaults()) {
-            $menu->setStyle($this->menu->getStyle());
-        }
 
         $this->menu->addItem($item = new MenuMenuItem(
             $text,
@@ -556,6 +544,28 @@ class CliMenuBuilder
             $this->style->setDisplaysExtra($this->itemsHaveExtra($this->menu->getItems()));
         }
 
+        if (!$this->subMenu) {
+            $this->propagateStyles($this->menu);
+        }
+
         return $this->menu;
+    }
+
+    /**
+     * Pass styles from current menu to sub-menu
+     * only if sub-menu style has not be customized
+     */
+    private function propagateStyles(CliMenu $menu)
+    {
+        foreach ($menu->getItems() as $item) {
+            if ($item instanceof MenuMenuItem) {
+                $subMenu = $item->getSubMenu();
+
+                !$subMenu->getStyle()->hasChangedFromDefaults()
+                    && $subMenu->setStyle(clone $menu->getStyle());
+
+                $this->propagateStyles($subMenu);
+            }
+        }
     }
 }

--- a/src/Builder/CliMenuBuilder.php
+++ b/src/Builder/CliMenuBuilder.php
@@ -555,9 +555,12 @@ class CliMenuBuilder
      * Pass styles from current menu to sub-menu
      * only if sub-menu style has not be customized
      */
-    private function propagateStyles(CliMenu $menu)
+    private function propagateStyles(CliMenu $menu, array $items = [])
     {
-        foreach ($menu->getItems() as $item) {
+        $currentItems = !empty($items) ? $items : $menu->getItems();
+
+        foreach ($currentItems as $item) {
+            // Apply current style to children, if they are not customized
             if ($item instanceof MenuMenuItem) {
                 $subMenu = $item->getSubMenu();
 
@@ -565,6 +568,11 @@ class CliMenuBuilder
                     && $subMenu->setStyle(clone $menu->getStyle());
 
                 $this->propagateStyles($subMenu);
+            }
+
+            // Apply styles to SplitItem children using current $menu
+            if ($item instanceof SplitItem) {
+                $this->propagateStyles($menu, $item->getItems());
             }
         }
     }

--- a/src/Builder/CliMenuBuilder.php
+++ b/src/Builder/CliMenuBuilder.php
@@ -564,8 +564,9 @@ class CliMenuBuilder
             if ($item instanceof MenuMenuItem) {
                 $subMenu = $item->getSubMenu();
 
-                !$subMenu->getStyle()->hasChangedFromDefaults()
-                    && $subMenu->setStyle(clone $menu->getStyle());
+                if (!$subMenu->getStyle()->hasChangedFromDefaults()) {
+                    $subMenu->setStyle(clone $menu->getStyle());
+                }
 
                 $this->propagateStyles($subMenu);
             }

--- a/test/Builder/CliMenuBuilderTest.php
+++ b/test/Builder/CliMenuBuilderTest.php
@@ -583,7 +583,7 @@ class CliMenuBuilderTest extends TestCase
             ->expects($this->any())
             ->method('getWidth')
             ->will($this->returnValue(200));
-        
+
         $menu = (new CliMenuBuilder($terminal))
             ->setBackgroundColour('green')
             ->addSubMenu('My SubMenu', function (CliMenuBuilder $b) {
@@ -594,7 +594,9 @@ class CliMenuBuilderTest extends TestCase
             })
             ->build();
 
+        /** @var CliMenu $subMenu1 */
         $subMenu1 = $menu->getItems()[0]->getSubMenu();
+        /** @var CliMenu $subMenu2 */
         $subMenu2 = $subMenu1->getItems()[0]->getSubMenu();
 
         self::assertSame('green', $subMenu1->getStyle()->getBg());
@@ -602,6 +604,35 @@ class CliMenuBuilderTest extends TestCase
 
         self::assertSame('green', $subMenu2->getStyle()->getBg());
         self::assertEquals($menu->getStyle(), $subMenu2->getStyle());
+    }
+
+    public function testSubMenuIgnoresParentsStyleIfCustomAndPassesToChildren() : void
+    {
+        $terminal = self::createMock(Terminal::class);
+        $terminal
+            ->expects($this->any())
+            ->method('getWidth')
+            ->will($this->returnValue(200));
+
+        $menu = (new CliMenuBuilder($terminal))
+            ->setBackgroundColour('green')
+            ->addSubMenu('My SubMenu', function (CliMenuBuilder $b) {
+                $b->setBackgroundColour('yellow')
+                    ->addSubMenu('My SubSubMenu', function (CliMenuBuilder $b) {
+                        $b->addItem('Some Item', function () {
+                        });
+                });
+            })
+            ->build();
+
+        /** @var CliMenu $subMenu1 */
+        $subMenu1 = $menu->getItems()[0]->getSubMenu();
+        /** @var CliMenu $subMenu2 */
+        $subMenu2 = $subMenu1->getItems()[0]->getSubMenu();
+
+        self::assertSame('green', $menu->getStyle()->getBg());
+        self::assertSame('yellow', $subMenu1->getStyle()->getBg());
+        self::assertSame('yellow', $subMenu2->getStyle()->getBg());
     }
 
     public function testSubMenuDoesNotInheritsParentsStyleWhenSubMenuStyleHasAlterations() : void

--- a/test/Builder/CliMenuBuilderTest.php
+++ b/test/Builder/CliMenuBuilderTest.php
@@ -619,9 +619,11 @@ class CliMenuBuilderTest extends TestCase
             ->setBackgroundColour('green')
             ->addSplitItem(function (SplitItemBuilder $b) {
                 $b
-                    ->addItem('Item 1', function () {})
+                    ->addItem('Item 1', function () {
+                    })
                     ->addSubMenu('Submenu 1', function (CliMenuBuilder $b) {
-                        $b->addItem('Item 2', function () {});
+                        $b->addItem('Item 2', function () {
+                        });
                     })
                 ;
             })
@@ -653,7 +655,7 @@ class CliMenuBuilderTest extends TestCase
                     ->addSubMenu('My SubSubMenu', function (CliMenuBuilder $b) {
                         $b->addItem('Some Item', function () {
                         });
-                });
+                    });
             })
             ->build();
 

--- a/test/Builder/CliMenuBuilderTest.php
+++ b/test/Builder/CliMenuBuilderTest.php
@@ -593,7 +593,7 @@ class CliMenuBuilderTest extends TestCase
             ->build();
 
         self::assertSame('green', $menu->getItems()[0]->getSubMenu()->getStyle()->getBg());
-        self::assertSame($menu->getStyle(), $menu->getItems()[0]->getSubMenu()->getStyle());
+        self::assertEquals($menu->getStyle(), $menu->getItems()[0]->getSubMenu()->getStyle());
     }
 
     public function testSubMenuDoesNotInheritsParentsStyleWhenSubMenuStyleHasAlterations() : void

--- a/test/Builder/CliMenuBuilderTest.php
+++ b/test/Builder/CliMenuBuilderTest.php
@@ -587,13 +587,21 @@ class CliMenuBuilderTest extends TestCase
         $menu = (new CliMenuBuilder($terminal))
             ->setBackgroundColour('green')
             ->addSubMenu('My SubMenu', function (CliMenuBuilder $b) {
-                $b->addItem('Some Item', function () {
+                $b->addSubMenu('My SubSubMenu', function (CliMenuBuilder $b) {
+                    $b->addItem('Some Item', function () {
+                    });
                 });
             })
             ->build();
 
-        self::assertSame('green', $menu->getItems()[0]->getSubMenu()->getStyle()->getBg());
-        self::assertEquals($menu->getStyle(), $menu->getItems()[0]->getSubMenu()->getStyle());
+        $subMenu1 = $menu->getItems()[0]->getSubMenu();
+        $subMenu2 = $subMenu1->getItems()[0]->getSubMenu();
+
+        self::assertSame('green', $subMenu1->getStyle()->getBg());
+        self::assertEquals($menu->getStyle(), $subMenu1->getStyle());
+
+        self::assertSame('green', $subMenu2->getStyle()->getBg());
+        self::assertEquals($menu->getStyle(), $subMenu2->getStyle());
     }
 
     public function testSubMenuDoesNotInheritsParentsStyleWhenSubMenuStyleHasAlterations() : void

--- a/test/Builder/CliMenuBuilderTest.php
+++ b/test/Builder/CliMenuBuilderTest.php
@@ -11,6 +11,7 @@ use PhpSchool\CliMenu\MenuItem\LineBreakItem;
 use PhpSchool\CliMenu\MenuItem\MenuMenuItem;
 use PhpSchool\CliMenu\MenuItem\RadioItem;
 use PhpSchool\CliMenu\MenuItem\SelectableItem;
+use PhpSchool\CliMenu\MenuItem\SplitItem;
 use PhpSchool\CliMenu\MenuItem\StaticItem;
 use PhpSchool\Terminal\Terminal;
 use PHPUnit\Framework\TestCase;
@@ -604,6 +605,37 @@ class CliMenuBuilderTest extends TestCase
 
         self::assertSame('green', $subMenu2->getStyle()->getBg());
         self::assertEquals($menu->getStyle(), $subMenu2->getStyle());
+    }
+
+    public function testSplitItemSubMenuInheritsParentsStyle() : void
+    {
+        $terminal = self::createMock(Terminal::class);
+        $terminal
+            ->expects($this->any())
+            ->method('getWidth')
+            ->will($this->returnValue(200));
+
+        $menu = (new CliMenuBuilder($terminal))
+            ->setBackgroundColour('green')
+            ->addSplitItem(function (SplitItemBuilder $b) {
+                $b
+                    ->addItem('Item 1', function () {})
+                    ->addSubMenu('Submenu 1', function (CliMenuBuilder $b) {
+                        $b->addItem('Item 2', function () {});
+                    })
+                ;
+            })
+            ->build();
+
+        /** @var SplitItem $splitItem */
+        $splitItem = $menu->getItems()[0];
+        /** @var SelectableItem $selectableItem1 */
+        $selectableItem1 = $splitItem->getItems()[0];
+        /** @var CliMenu $subMenu */
+        $subMenu = $splitItem->getItems()[1]->getSubMenu();
+
+        self::assertSame('green', $subMenu->getStyle()->getBg());
+        self::assertEquals($menu->getStyle(), $subMenu->getStyle());
     }
 
     public function testSubMenuIgnoresParentsStyleIfCustomAndPassesToChildren() : void


### PR DESCRIPTION
Test code:

```
<?php

use PhpSchool\CliMenu\CliMenu;
use PhpSchool\CliMenu\Builder\CliMenuBuilder;

require_once(__DIR__ . '/../vendor/autoload.php');

$menu = (new CliMenuBuilder)
    ->setBackgroundColour('black')
    ->setForegroundColour('green')
    ->setTitle('Color Test #1')
    ->addLineBreak()
    ->addSubMenu('Submenu #1', function (CliMenuBuilder $b) {
        $b->setTitle('Color Test #2')
            ->addLineBreak()
            ->addSubMenu('Submenu #2', function (CliMenuBuilder $b) {
                $b->setTitle('Color Test #3')
                    ->addLineBreak()
                    ->addItem('Foo #6', function (CliMenu $menu) {})
                    ->addItem('Foo #7', function (CliMenu $menu) {})
                    ->addLineBreak()
                ;
            })
            ->addItem('Foo #4', function (CliMenu $menu) {})
            ->addItem('Foo #5', function (CliMenu $menu) {})
            ->addLineBreak()
        ;
    })
    ->addItem('Foo #2', function (CliMenu $menu) {})
    ->addItem('Foo #3', function (CliMenu $menu) {})
    ->addLineBreak()
    ->build()
;

$menu->open();
```