### PR TITLE
Auto resize width

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     "require": {
         "php" : ">=7.1",
         "beberlei/assert": "^2.4 | ^3",
-        "php-school/terminal": "^0.2.1",
+        "php-school/terminal": "dev-feature/signals",
         "ext-posix": "*"
     },
     "autoload" : {

--- a/examples/submenu.php
+++ b/examples/submenu.php
@@ -22,6 +22,7 @@ $menu = (new CliMenuBuilder)
             ->addLineBreak('-');
     })
     ->setWidth(70)
+    ->setMarginAuto()
     ->setBackgroundColour('yellow')
     ->build();
 

--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -116,6 +116,14 @@ class CliMenu
         $this->radioStyle      = new RadioStyle();
         $this->selectableStyle = new SelectableStyle();
 
+        $this->terminal->onSignal(SIGWINCH, function () {
+            $this->style->windowResize();
+
+            if ($this->isOpen()) {
+                $this->redraw(true);
+            }
+        });
+
         $this->selectFirstItem();
     }
 
@@ -295,6 +303,12 @@ class CliMenu
 
         while ($this->isOpen()) {
             $char = $reader->readCharacter();
+
+            if (null === $char) {
+                usleep(10000);
+                continue;
+            }
+
             if (!$char->isHandledControl()) {
                 $rawChar = $char->get();
                 if (isset($this->customControlMappings[$rawChar])) {

--- a/src/MenuStyle.php
+++ b/src/MenuStyle.php
@@ -53,6 +53,15 @@ class MenuStyle
     private $requestedWidth;
 
     /**
+     * If the window was resized, we store the original
+     * size, before any resizing, to attempt to restore
+     * it on a later resize.
+     *
+     * @var int
+     */
+    private $widthBeforeResize;
+
+    /**
      * @var int
      */
     protected $margin = 0;
@@ -402,6 +411,7 @@ class MenuStyle
         $this->requestedWidth = $width;
         $width = $this->maybeShrinkWidth($this->margin, $width);
 
+        $this->widthBeforeResize = null;
         $this->width = $width;
         if ($this->marginAuto) {
             $this->calculateMarginAuto($width);
@@ -421,6 +431,24 @@ class MenuStyle
         }
 
         return $width;
+    }
+
+    public function windowResize() : void
+    {
+        if (null === $this->widthBeforeResize) {
+            $this->widthBeforeResize = $this->width;
+        }
+
+        $width = $this->maybeShrinkWidth($this->margin, $this->widthBeforeResize);
+
+        $this->width = $width;
+        if ($this->marginAuto) {
+            $this->calculateMarginAuto($width);
+        }
+
+        $this->calculateContentWidth();
+        $this->generateBorderRows();
+        $this->generatePaddingTopBottomRows();
     }
 
     public function getPaddingTopBottom() : int

--- a/src/Terminal/TerminalFactory.php
+++ b/src/Terminal/TerminalFactory.php
@@ -2,6 +2,7 @@
 
 namespace PhpSchool\CliMenu\Terminal;
 
+use PhpSchool\Terminal\IO\NonBlockingResourceInputStream;
 use PhpSchool\Terminal\IO\ResourceInputStream;
 use PhpSchool\Terminal\IO\ResourceOutputStream;
 use PhpSchool\Terminal\Terminal;
@@ -14,6 +15,6 @@ class TerminalFactory
 {
     public static function fromSystem() : Terminal
     {
-        return new UnixTerminal(new ResourceInputStream, new ResourceOutputStream);
+        return new UnixTerminal(new NonBlockingResourceInputStream, new ResourceOutputStream);
     }
 }


### PR DESCRIPTION
An attempt at resizing the menu when the terminal is resized. It seems to be a bit jittery, some resizes work, some do not.

It works when first being resized, storing the width of the menu. Every time it is resized, we will attempt to set the original width, which will either shrink the menu if the terminal is too small to display it, or if the terminal is enlarged, it will attempt to display the menu at its original width.

Needs https://github.com/php-school/terminal/pull/12

And is based on top off #220 so can be rebased when that is merged to reduce the diff.