### PR TITLE
feat(password): Make password having custom length

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "php" : ">=7.1",
         "beberlei/assert": "^2.4 | ^3",
         "php-school/terminal": "^0.2.1",
-        "ext-posix": "*"
+        "ext-posix": "*",
+        "ext-mbstring": "*"
     },
     "autoload" : {
         "psr-4" : {

--- a/src/Input/Password.php
+++ b/src/Input/Password.php
@@ -39,6 +39,11 @@ class Password implements Input
      */
     private $style;
 
+    /**
+     * @var int
+     */
+    private $passwordLength = 16;
+
     public function __construct(InputIO $inputIO, MenuStyle $style)
     {
         $this->inputIO = $inputIO;
@@ -84,7 +89,7 @@ class Password implements Input
     public function setValidator(callable $validator) : Input
     {
         $this->validator = $validator;
-        
+
         return $this;
     }
 
@@ -97,15 +102,15 @@ class Password implements Input
     {
         if ($this->validator) {
             $validator = $this->validator;
-            
+
             if ($validator instanceof \Closure) {
                 $validator = $validator->bindTo($this);
             }
-            
+
             return $validator($input);
         }
 
-        return mb_strlen($input) >= 16;
+        return mb_strlen($input) >= $this->passwordLength;
     }
 
     public function filter(string $value) : string
@@ -116,5 +121,10 @@ class Password implements Input
     public function getStyle() : MenuStyle
     {
         return $this->style;
+    }
+
+    public function setPasswordLength(int $length) : int
+    {
+        return $this->passwordLength = $length;
     }
 }

--- a/test/Input/PasswordTest.php
+++ b/test/Input/PasswordTest.php
@@ -25,7 +25,7 @@ class PasswordTest extends TestCase
     private $inputIO;
 
     /**
-     * @var Text
+     * @var Password
      */
     private $input;
 
@@ -131,9 +131,23 @@ class PasswordTest extends TestCase
         };
 
         $this->input->setValidator($customValidate);
-        
+
         self::assertTrue($this->input->validate('superstrongpassword'));
         self::assertFalse($this->input->validate('mypassword'));
         self::assertEquals('Password too generic', $this->input->getValidationFailedText());
+    }
+
+    public function testPasswordValidationWithDefaultLength() : void
+    {
+        self::assertFalse($this->input->validate(str_pad('a', 15)));
+        self::assertTrue($this->input->validate(str_pad('a', 16)));
+    }
+
+    public function testPasswordValidationWithDefinedLength() : void
+    {
+        $this->input->setPasswordLength(5);
+
+        self::assertFalse($this->input->validate(str_pad('a', 4)));
+        self::assertTrue($this->input->validate(str_pad('a', 5)));
     }
 }


### PR DESCRIPTION
### Why

Hello :)

I'm currently using your api to make a php cli menu for my app.
I've been facing a problem when I wanted to make a user registration area.

- I ask to users to type their passwords
    - the password length is hard-coded in the code and it's 16 characters length
    - I don't want to give a closure to custom validator method because I think it's too much effort

So the aim of my pull request is to allow developers like me to call a setter in order to give another length. Of course, I made it backward-compatible so the previous value is a default value if the new method is not called.

### Description 
- fix phpdoc type error in password unit test
- add new internal property about password length with default value int "16"
- replace hard coded password length comparison with that internal property
- add a new setter for a custom password length
- add missing ext-mbstring to composer.json
- add setValidator to Input interface
- add tests in PasswordTest