### PR TITLE
Improve the formatting of disabled menu items in different terminals

### DIFF
--- a/src/MenuStyle.php
+++ b/src/MenuStyle.php
@@ -277,20 +277,30 @@ class MenuStyle
         return $currentValues !== array_values($defaultStyleValues);
     }
 
+    /**
+     * Get text for a disabled menu item.
+     *
+     * This sets the foreground colour to the ansi bright equivalent,
+     * and on supported terminals, adds additional dim formatting.
+     *
+     * @return string
+     */
     public function getDisabledItemText(string $text) : string
     {
         return sprintf(
-            "\033[%sm%s\033[%sm",
+            "\033[%sm\033[%sm%s\033[%sm\033[%sm",
             self::$availableOptions['dim']['set'],
+            $this->getForegroundColourCode() + 60,
             $text,
+            $this->getBackgroundColourCode(),
             self::$availableOptions['dim']['unset']
         );
     }
 
     /**
-     * Generates the ansi escape sequence to set the colours
+     * Get the ansi escape sequence for the foreground colour.
      */
-    private function generateColoursSetCode() : void
+    private function getForegroundColourCode()
     {
         if (!ctype_digit($this->fg)) {
             $fgCode = self::$availableForegroundColors[$this->fg];
@@ -298,13 +308,33 @@ class MenuStyle
             $fgCode = sprintf("38;5;%s", $this->fg);
         }
 
+        return $fgCode;
+    }
+
+    /**
+     * Get the ansi escape sequence for the background colour.
+     */
+    private function getBackgroundColourCode()
+    {
         if (!ctype_digit($this->bg)) {
             $bgCode = self::$availableBackgroundColors[$this->bg];
         } else {
             $bgCode = sprintf("48;5;%s", $this->bg);
         }
 
-        $this->coloursSetCode = sprintf("\033[%s;%sm", $fgCode, $bgCode);
+        return $bgCode;
+    }
+
+    /**
+     * Generates the ansi escape sequence to set the colours
+     */
+    private function generateColoursSetCode() : void
+    {
+        $this->coloursSetCode = sprintf(
+            "\033[%s;%sm",
+            $this->getForegroundColourCode(),
+            $this->getBackgroundColourCode()
+        );
     }
 
     /**

--- a/src/MenuStyle.php
+++ b/src/MenuStyle.php
@@ -290,7 +290,7 @@ class MenuStyle
         return sprintf(
             "\033[%sm\033[%sm%s\033[%sm\033[%sm",
             self::$availableOptions['dim']['set'],
-            $this->getForegroundColourCode() + 60,
+            $this->getForegroundColourCode(true),
             $text,
             $this->getForegroundColourCode(),
             self::$availableOptions['dim']['unset']
@@ -300,33 +300,39 @@ class MenuStyle
     /**
      * Get the ansi escape sequence for the foreground colour.
      *
+     * @param bool $bright Whether to modify to the ansi bright variation
+     *
      * @return string
      */
-    private function getForegroundColourCode() : string
+    private function getForegroundColourCode(bool $bright = false) : string
     {
         if (!ctype_digit($this->fg)) {
-            $fgCode = self::$availableForegroundColors[$this->fg];
+            $fgCode = (int)self::$availableForegroundColors[$this->fg];
+            $fgCode += ($bright ? 60 : 0);
         } else {
-            $fgCode = sprintf("38;5;%s", $this->fg);
+            $fgCode = sprintf("38;5;%s", ((int)$this->fg + ($bright ? 60 : 0)));
         }
 
-        return $fgCode;
+        return (string)$fgCode;
     }
 
     /**
      * Get the ansi escape sequence for the background colour.
      *
+     * @param bool $bright Whether to modify to the ansi bright variation
+     *
      * @return string
      */
-    private function getBackgroundColourCode() : string
+    private function getBackgroundColourCode(bool $bright = false) : string
     {
         if (!ctype_digit($this->bg)) {
-            $bgCode = self::$availableBackgroundColors[$this->bg];
+            $bgCode = (int)self::$availableBackgroundColors[$this->bg];
+            $bgCode += ($bright ? 60 : 0);
         } else {
-            $bgCode = sprintf("48;5;%s", $this->bg);
+            $bgCode = sprintf("48;5;%s", ((int)$this->bg + ($bright ? 60 : 0)));
         }
 
-        return $bgCode;
+        return (string)$bgCode;
     }
 
     /**

--- a/src/MenuStyle.php
+++ b/src/MenuStyle.php
@@ -292,7 +292,7 @@ class MenuStyle
             self::$availableOptions['dim']['set'],
             $this->getForegroundColourCode() + 60,
             $text,
-            $this->getBackgroundColourCode(),
+            $this->getForegroundColourCode(),
             self::$availableOptions['dim']['unset']
         );
     }

--- a/src/MenuStyle.php
+++ b/src/MenuStyle.php
@@ -299,8 +299,10 @@ class MenuStyle
 
     /**
      * Get the ansi escape sequence for the foreground colour.
+     *
+     * @return string
      */
-    private function getForegroundColourCode()
+    private function getForegroundColourCode() : string
     {
         if (!ctype_digit($this->fg)) {
             $fgCode = self::$availableForegroundColors[$this->fg];
@@ -313,8 +315,10 @@ class MenuStyle
 
     /**
      * Get the ansi escape sequence for the background colour.
+     *
+     * @return string
      */
-    private function getBackgroundColourCode()
+    private function getBackgroundColourCode() : string
     {
         if (!ctype_digit($this->bg)) {
             $bgCode = self::$availableBackgroundColors[$this->bg];

--- a/test/MenuItem/SelectableItemRendererTest.php
+++ b/test/MenuItem/SelectableItemRendererTest.php
@@ -84,16 +84,14 @@ class SelectableItemRendererTest extends TestCase
         $menuStyle->setWidth(35);
         $style = (new SelectableStyle())->setItemExtra('[DONE]');
 
-        $item = new SelectableItem('SOME TEXT', function () {
+        $item = new SelectableItem($testString = 'SOME TEXT', function () {
         });
         $item->setStyle($style);
         $item->showItemExtra();
 
         self::assertEquals(
-            [
-                "\033[2m● SOME TEXT\033[22m              [DONE]",
-            ],
-            $renderer->render($menuStyle, $item, true, true)
+            escapeshellcmd("\033[2m\033[97m● " . $testString . "\033[37m\033[22m              [DONE]"),
+            escapeshellcmd($renderer->render($menuStyle, $item, true, true)[0])
         );
     }
     public function testWrapAndIndentText() : void


### PR DESCRIPTION
I spent ages wondering why my disabled menu item didn't look like it was disabled, and eventually I figured out it's just that some Terminals don't support some of the less common ANSI escape sequences.

In my case, I was using PhpStorm's built-in Terminal window — which is obviously going to be a pretty common choice for users of this package — so here's a PR for a workaround.

* Disabled items are now modified to use the ANSI "bright" equivalent of the same colour as their foreground text
* To get a bright ANSI colour, just add `60` to an existing colour code
* This bright effect makes both black and white text look greyed-out, and works well with other colours too
* The bright text is then wrapped in the original dim modifier, to enhance the effect further in Terminals that do support dimming

Whilst I was researching what was going wrong, [I found this list](https://unix.stackexchange.com/a/552289
) comparing support for the blink effect across different popular terminals. Though it's obviously for a different effect it does go to show you can't expect every terminal to support dimming.