### PR TITLE
Allow the use of callables to determine whether a menu item is disabled or not

### DIFF
--- a/README.md
+++ b/README.md
@@ -791,6 +791,13 @@ $menu = (new CliMenuBuilder)
             ->addItem('Nope can\'t see this!', $itemCallable)
             ->disableMenu();
     })
+    ->setTitle('Basic CLI Menu Disabled Items > Dynamic Submenu')
+    ->addItem(
+        'You can only select this item at the weekend!',
+        $itemCallable,
+        false,
+        fn() => (date('N') < 6)
+    )
     ->addLineBreak('-')
     ->build();
 ```

--- a/README.md
+++ b/README.md
@@ -791,7 +791,6 @@ $menu = (new CliMenuBuilder)
             ->addItem('Nope can\'t see this!', $itemCallable)
             ->disableMenu();
     })
-    ->setTitle('Basic CLI Menu Disabled Items > Dynamic Submenu')
     ->addItem(
         'You can only select this item at the weekend!',
         $itemCallable,

--- a/src/Builder/CliMenuBuilder.php
+++ b/src/Builder/CliMenuBuilder.php
@@ -123,6 +123,16 @@ class CliMenuBuilder
         return $this;
     }
 
+    /**
+     * Add an item to the menu.
+     *
+     * @param string        $text
+     * @param callable      $itemCallable
+     * @param bool          $showItemExtra
+     * @param bool|callable $disabled
+     *
+     * @return $this
+     */
     public function addItem(
         string $text,
         callable $itemCallable,
@@ -143,6 +153,16 @@ class CliMenuBuilder
         return $this;
     }
 
+    /**
+     * Add a checkbox to the menu.
+     *
+     * @param string        $text
+     * @param callable      $itemCallable
+     * @param bool          $showItemExtra
+     * @param bool|callable $disabled
+     *
+     * @return $this
+     */
     public function addCheckboxItem(
         string $text,
         callable $itemCallable,
@@ -154,6 +174,16 @@ class CliMenuBuilder
         return $this;
     }
 
+    /**
+     * Add a radio button to the menu.
+     *
+     * @param string        $text
+     * @param callable      $itemCallable
+     * @param bool          $showItemExtra
+     * @param bool|callable $disabled
+     *
+     * @return $this
+     */
     public function addRadioItem(
         string $text,
         callable $itemCallable,

--- a/src/Builder/CliMenuBuilder.php
+++ b/src/Builder/CliMenuBuilder.php
@@ -127,7 +127,7 @@ class CliMenuBuilder
         string $text,
         callable $itemCallable,
         bool $showItemExtra = false,
-        bool $disabled = false
+        $disabled = false
     ) : self {
         $this->addMenuItem(new SelectableItem($text, $itemCallable, $showItemExtra, $disabled));
 
@@ -147,7 +147,7 @@ class CliMenuBuilder
         string $text,
         callable $itemCallable,
         bool $showItemExtra = false,
-        bool $disabled = false
+        $disabled = false
     ) : self {
         $this->addMenuItem(new CheckboxItem($text, $itemCallable, $showItemExtra, $disabled));
 
@@ -158,7 +158,7 @@ class CliMenuBuilder
         string $text,
         callable $itemCallable,
         bool $showItemExtra = false,
-        bool $disabled = false
+        $disabled = false
     ) : self {
         $this->addMenuItem(new RadioItem($text, $itemCallable, $showItemExtra, $disabled));
 

--- a/src/MenuItem/CheckboxItem.php
+++ b/src/MenuItem/CheckboxItem.php
@@ -25,7 +25,7 @@ class CheckboxItem implements MenuItemInterface
     private $showItemExtra;
 
     /**
-     * @var bool
+     * @var bool|callable
      */
     private $disabled;
 
@@ -41,6 +41,16 @@ class CheckboxItem implements MenuItemInterface
      */
     private $style;
 
+    /**
+     * CheckboxItem constructor.
+     *
+     * @param string        $text
+     * @param callable      $selectAction
+     * @param bool          $showItemExtra
+     * @param bool|callable $disabled
+     *
+     * @return void
+     */
     public function __construct(
         string $text,
         callable $selectAction,

--- a/src/MenuItem/CheckboxItem.php
+++ b/src/MenuItem/CheckboxItem.php
@@ -45,7 +45,7 @@ class CheckboxItem implements MenuItemInterface
         string $text,
         callable $selectAction,
         bool $showItemExtra = false,
-        bool $disabled = false
+        $disabled = false
     ) {
         $this->text = $text;
         $this->selectAction = $selectAction;
@@ -60,7 +60,7 @@ class CheckboxItem implements MenuItemInterface
      */
     public function getRows(MenuStyle $style, bool $selected = false) : array
     {
-        return (new SelectableItemRenderer())->render($style, $this, $selected, $this->disabled);
+        return (new SelectableItemRenderer())->render($style, $this, $selected, ! $this->canSelect());
     }
 
     /**
@@ -97,7 +97,9 @@ class CheckboxItem implements MenuItemInterface
      */
     public function canSelect() : bool
     {
-        return !$this->disabled;
+        return is_callable($this->disabled)
+            ? (! call_user_func($this->disabled))
+            : (! $this->disabled);
     }
 
     /**

--- a/src/MenuItem/RadioItem.php
+++ b/src/MenuItem/RadioItem.php
@@ -45,7 +45,7 @@ class RadioItem implements MenuItemInterface
         string $text,
         callable $selectAction,
         bool $showItemExtra = false,
-        bool $disabled = false
+        $disabled = false
     ) {
         $this->text = $text;
         $this->selectAction = $selectAction;
@@ -60,7 +60,7 @@ class RadioItem implements MenuItemInterface
      */
     public function getRows(MenuStyle $style, bool $selected = false) : array
     {
-        return (new SelectableItemRenderer())->render($style, $this, $selected, $this->disabled);
+        return (new SelectableItemRenderer())->render($style, $this, $selected, ! $this->canSelect());
     }
 
     /**
@@ -117,7 +117,9 @@ class RadioItem implements MenuItemInterface
      */
     public function canSelect() : bool
     {
-        return !$this->disabled;
+        return is_callable($this->disabled)
+            ? (! call_user_func($this->disabled))
+            : (! $this->disabled);
     }
 
     /**

--- a/src/MenuItem/RadioItem.php
+++ b/src/MenuItem/RadioItem.php
@@ -25,7 +25,7 @@ class RadioItem implements MenuItemInterface
     private $showItemExtra;
 
     /**
-     * @var bool
+     * @var bool|callable
      */
     private $disabled;
 
@@ -41,6 +41,16 @@ class RadioItem implements MenuItemInterface
      */
     private $style;
 
+    /**
+     * RadioItem constructor.
+     *
+     * @param string        $text
+     * @param callable      $selectAction
+     * @param bool          $showItemExtra
+     * @param bool|callable $disabled
+     *
+     * @return void
+     */
     public function __construct(
         string $text,
         callable $selectAction,

--- a/src/MenuItem/SelectableItem.php
+++ b/src/MenuItem/SelectableItem.php
@@ -29,7 +29,7 @@ class SelectableItem implements MenuItemInterface
     private $showItemExtra;
 
     /**
-     * @var bool
+     * @var bool|callable
      */
     private $disabled;
 
@@ -38,6 +38,16 @@ class SelectableItem implements MenuItemInterface
      */
     private $style;
 
+    /**
+     * SelectableItem constructor.
+     *
+     * @param string        $text
+     * @param callable      $selectAction
+     * @param bool          $showItemExtra
+     * @param bool|callable $disabled
+     *
+     * @return void
+     */
     public function __construct(
         string $text,
         callable $selectAction,

--- a/src/MenuItem/SelectableItem.php
+++ b/src/MenuItem/SelectableItem.php
@@ -42,7 +42,7 @@ class SelectableItem implements MenuItemInterface
         string $text,
         callable $selectAction,
         bool $showItemExtra = false,
-        bool $disabled = false
+        $disabled = false
     ) {
         $this->text = $text;
         $this->selectAction = $selectAction;
@@ -57,7 +57,7 @@ class SelectableItem implements MenuItemInterface
      */
     public function getRows(MenuStyle $style, bool $selected = false) : array
     {
-        return (new SelectableItemRenderer())->render($style, $this, $selected, $this->disabled);
+        return (new SelectableItemRenderer())->render($style, $this, $selected, ! $this->canSelect());
     }
 
     /**
@@ -89,7 +89,9 @@ class SelectableItem implements MenuItemInterface
      */
     public function canSelect() : bool
     {
-        return !$this->disabled;
+        return is_callable($this->disabled)
+            ? (! call_user_func($this->disabled))
+            : (! $this->disabled);
     }
 
     /**


### PR DESCRIPTION
It's easy enough to set a menu item as disabled, but what if you want to re-enable it following a user action within the menu? I couldn't see a clean way to do this (hopefully I'm not missing something...!), so this PR should fix it.

It simply changes the method definitions for `addItem`, `addCheckboxItem`, and `addRadioItem` to allow the `$disabled` parameter to be a boolean or a callable. When an item is selected that toggles the state of another item, a call to `$menu->redraw()` refreshes the screen and updates the status of the item.

Here's an example of how it works. I put another simple example in the README file too.

```php
public bool $isChecked = false;

public function showMenu(): void
{
    $itemSelected     = function (CliMenu $menu) {
        $menu->redraw();
        $menu->flash('Item selected!')->display();
    };
    $checkboxSelected = function (CliMenu $menu) use ($itemSelected) {
        $this->isChecked = true;
        $itemSelected($menu);
    };

    (new CliMenuBuilder)
        ->setTitle('Callable Functions')
        ->addCheckboxItem(
            'Check this box...',
            $checkboxSelected,
            false,
            fn() => $this->isChecked
        )->addItem(
            'This item is enabled if the checkbox is not ticked',
            $itemSelected,
            false,
            fn() => $this->isChecked
        )->addRadioItem(
            'These radio buttons are enabled if the checkbox is selected',
            $itemSelected,
            false,
            fn() => ! $this->isChecked
        )->addRadioItem(
            'These radio buttons are enabled if the checkbox is selected',
            $itemSelected,
            false,
            fn() => ! $this->isChecked
        )
        ->build()
        ->open();
}
```