### PR TITLE
Adds the ability to add multiple checkbox and radio items

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,6 +575,27 @@ $menu = (new CliMenuBuilder)
     ->build();
 ```
 
+You can add multiple checkbox items at once like so:
+
+```php
+<?php
+
+use PhpSchool\CliMenu\Builder\CliMenuBuilder;
+use PhpSchool\CliMenu\CliMenu;
+
+$callable = function (CliMenu $menu) {
+    echo 'I am alive!';
+};
+
+$menu = (new CliMenuBuilder)
+    ->addCheckboxItems([
+        ['Item 1', $callable],
+        ['Item 2', $callable],
+        ['Item 3', $callable],
+    ])
+    ->build();
+```
+
 When selecting an item, it will be toggled. Notice at first each item is unchecked. After selecting one it will become
 checked.
 
@@ -594,6 +615,27 @@ $menu = (new CliMenuBuilder)
     ->addRadioItem('Item 1', $callable)
     ->addRadioItem('Item 2', $callable)
     ->addRadioItem('Item 3', $callable)
+    ->build();
+```
+
+You can add multiple radio items at once like so:
+
+```php
+<?php
+
+use PhpSchool\CliMenu\Builder\CliMenuBuilder;
+use PhpSchool\CliMenu\CliMenu;
+
+$callable = function (CliMenu $menu) {
+    echo 'I am alive!';
+};
+
+$menu = (new CliMenuBuilder)
+    ->addRadioItems([
+        ['Item 1', $callable],
+        ['Item 2', $callable],
+        ['Item 3', $callable],
+    ])
     ->build();
 ```
 

--- a/examples/checkbox-item.php
+++ b/examples/checkbox-item.php
@@ -15,10 +15,12 @@ $menu = (new CliMenuBuilder)
     ->addSubMenu('Compiled', function (CliMenuBuilder $b) use ($itemCallable) {
         $b->setTitle('Compiled Languages')
             ->addCheckboxItem('Rust', $itemCallable)
-            ->addCheckboxItem('C++', $itemCallable)
             ->addCheckboxItem('Go', $itemCallable)
             ->addCheckboxItem('Java', $itemCallable)
-            ->addCheckboxItem('C', $itemCallable)
+            ->addCheckboxItems([
+                ['C++', $itemCallable],
+                ['C', $itemCallable]
+            ]);
         ;
     })
     ->addSubMenu('Interpreted', function (CliMenuBuilder $b) use ($itemCallable) {

--- a/examples/radio-item.php
+++ b/examples/radio-item.php
@@ -15,10 +15,12 @@ $menu = (new CliMenuBuilder)
     ->addSubMenu('Compiled', function (CliMenuBuilder $b) use ($itemCallable) {
         $b->setTitle('Compiled Languages')
             ->addRadioItem('Rust', $itemCallable)
-            ->addRadioItem('C++', $itemCallable)
             ->addRadioItem('Go', $itemCallable)
             ->addRadioItem('Java', $itemCallable)
-            ->addRadioItem('C', $itemCallable)
+            ->addRadioItems([
+                ['C++', $itemCallable],
+                ['C', $itemCallable]
+            ])
         ;
     })
     ->addSubMenu('Interpreted', function (CliMenuBuilder $b) use ($itemCallable) {

--- a/src/Builder/CliMenuBuilder.php
+++ b/src/Builder/CliMenuBuilder.php
@@ -154,6 +154,15 @@ class CliMenuBuilder
         return $this;
     }
 
+    public function addCheckboxItems(array $items): self
+    {
+        foreach ($items as $item) {
+            $this->addCheckboxItem(...$item);
+        }
+
+        return $this;
+    }
+
     public function addRadioItem(
         string $text,
         callable $itemCallable,
@@ -161,6 +170,15 @@ class CliMenuBuilder
         bool $disabled = false
     ) : self {
         $this->addMenuItem(new RadioItem($text, $itemCallable, $showItemExtra, $disabled));
+
+        return $this;
+    }
+
+    public function addRadioItems(array $items): self
+    {
+        foreach ($items as $item) {
+            $this->addRadioItem(...$item);
+        }
 
         return $this;
     }

--- a/test/Builder/CliMenuBuilderTest.php
+++ b/test/Builder/CliMenuBuilderTest.php
@@ -375,6 +375,33 @@ class CliMenuBuilderTest extends TestCase
         $this->checkMenuItems($menu, $expected);
     }
 
+    public function testAddMultipleCheckboxItems() : void
+    {
+        $callable = function () {
+        };
+
+        $builder = new CliMenuBuilder;
+        $builder->disableDefaultItems();
+        $builder->addCheckboxItems([
+            ['Item 1', $callable],
+            ['Item 2', $callable]
+        ]);
+        $menu = $builder->build();
+
+        $expected = [
+            [
+                'class' => CheckboxItem::class,
+                'text'  => 'Item 1',
+            ],
+            [
+                'class' => CheckboxItem::class,
+                'text'  => 'Item 2',
+            ],
+        ];
+
+        $this->checkMenuItems($menu, $expected);
+    }
+
     public function testAddCheckboxItem() : void
     {
         $callable = function () {
@@ -409,6 +436,33 @@ class CliMenuBuilderTest extends TestCase
         $builder->disableDefaultItems();
         $builder->addRadioItem('Item 1', $callable);
         $builder->addRadioItem('Item 2', $callable);
+        $menu = $builder->build();
+
+        $expected = [
+            [
+                'class' => RadioItem::class,
+                'text'  => 'Item 1',
+            ],
+            [
+                'class' => RadioItem::class,
+                'text'  => 'Item 2',
+            ],
+        ];
+
+        $this->checkMenuItems($menu, $expected);
+    }
+
+    public function testAddMultipleRadioItems() : void
+    {
+        $callable = function () {
+        };
+
+        $builder = new CliMenuBuilder;
+        $builder->disableDefaultItems();
+        $builder->addRadioItems([
+            ['Item 1', $callable],
+            ['Item 2', $callable],
+        ]);
         $menu = $builder->build();
 
         $expected = [


### PR DESCRIPTION
This PR adds the ability to add multipe checkbox and radio items at once.

# Examples:

## Checkbox 

```php
<?php

use PhpSchool\CliMenu\Builder\CliMenuBuilder;
use PhpSchool\CliMenu\CliMenu;

$callable = function (CliMenu $menu) {
    echo 'I am alive!';
};

$menu = (new CliMenuBuilder)
    ->addCheckboxItems([
        ['Item 1', $callable],
        ['Item 2', $callable],
        ['Item 3', $callable],
    ])
    ->build();
```

## Radio
```php
<?php

use PhpSchool\CliMenu\Builder\CliMenuBuilder;
use PhpSchool\CliMenu\CliMenu;

$callable = function (CliMenu $menu) {
    echo 'I am alive!';
};

$menu = (new CliMenuBuilder)
    ->addRadioItems([
        ['Item 1', $callable],
        ['Item 2', $callable],
        ['Item 3', $callable],
    ])
    ->build();
```