### PR TITLE
Fixed problem with package installation on Windows

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,12 @@
         "php" : ">=7.1",
         "beberlei/assert": "^2.4 | ^3",
         "php-school/terminal": "^0.2.1",
-        "ext-posix": "*",
         "ext-mbstring": "*"
+    },
+    "config": {
+        "platform": {
+            "ext-posix": "*"
+        }
     },
     "autoload" : {
         "psr-4" : {


### PR DESCRIPTION
This update needs to prevent usage "composer install --ignore-platform-reqs" everytime on Windows (not posix system).
Source of idea - https://stackoverflow.com/a/52778992