### PR TITLE
Fix using BACKSPACE key in input dialogs

### DIFF
--- a/src/Input/InputIO.php
+++ b/src/Input/InputIO.php
@@ -75,9 +75,11 @@ class InputIO
                         }
 
                     case InputCharacter::BACKSPACE:
-                        $inputValue = substr($inputValue, 0, -1);
-                        $this->parentMenu->redraw();
-                        $this->drawInput($input, $inputValue);
+                        if (!empty($inputValue)) {
+                            $inputValue = substr($inputValue, 0, -1);
+                            $this->parentMenu->redraw();
+                            $this->drawInput($input, $inputValue);
+                        }
                         continue 2;
                 }
 


### PR DESCRIPTION
This hotfix provides a solution to the problem below

#### Problem:
- Input error when using button BACKSPACE

#### Reproduce:
Hold down the BACKSPACE key in any input dialog from the examples folder.

#### Get error:
```
PHP Fatal error:  Uncaught TypeError: Argument 2 passed to PhpSchool\CliMenu\Input\InputIO::drawInput() must be of the type string, bool given, called in /opt/hg/cli-menu/src/Input/InputIO.php on line 80 and defined in /opt/hg/cli-menu/src/Input/InputIO.php:205
Stack trace:
#0 /opt/hg/cli-menu/src/Input/InputIO.php(80): PhpSchool\CliMenu\Input\InputIO->drawInput()
#1 /opt/hg/cli-menu/src/Input/Text.php(94): PhpSchool\CliMenu\Input\InputIO->collect()
#2 /opt/hg/cli-menu/examples/input-text.php(12): PhpSchool\CliMenu\Input\Text->ask()
#3 /opt/hg/cli-menu/src/CliMenu.php(459): {closure}()
#4 /opt/hg/cli-menu/src/CliMenu.php(311): PhpSchool\CliMenu\CliMenu->executeCurrentItem()
#5 /opt/hg/cli-menu/src/CliMenu.php(595): PhpSchool\CliMenu\CliMenu->display()
#6 /opt/hg/cli-menu/examples/input-text.php(26): PhpSchool\CliMenu\CliMenu->open()
#7 {main}
  thrown in /opt/hg/cli-menu/src/Input/InputIO.php on line 205
```

#### Expected
- continue working without errors