### PR TITLE
Fix backspace on empty input issue.

### DIFF
--- a/src/Input/InputIO.php
+++ b/src/Input/InputIO.php
@@ -77,6 +77,9 @@ class InputIO
                     case InputCharacter::BACKSPACE:
                         if (!empty($inputValue)) {
                             $inputValue = substr($inputValue, 0, -1);
+                            if (!is_string($inputValue)) {
+                                $inputValue = '';
+                            }
                             $this->parentMenu->redraw();
                             $this->drawInput($input, $inputValue);
                         }


### PR DESCRIPTION
This fixes the crash bug that occurs when attempting to remove a character from an empty string in PHP 7, triggered when hitting backspace in an empty text input field.