### PR TITLE
support full-width unicode characters

### DIFF
--- a/src/Builder/CliMenuBuilder.php
+++ b/src/Builder/CliMenuBuilder.php
@@ -268,7 +268,7 @@ class CliMenuBuilder
             return null;
         }
 
-        if (mb_strlen($match[1]) > 1) {
+        if (mb_strwidth($match[1]) > 1) {
             throw InvalidShortcutException::fromShortcut($match[1]);
         }
 

--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -569,7 +569,7 @@ class CliMenu
                 $invertedColoursSetCode,
                 str_repeat(' ', $this->style->getPaddingLeftRight()),
                 $row,
-                str_repeat(' ', $this->style->getRightHandPadding(mb_strlen(s::stripAnsiEscapeSequence($row)))),
+                str_repeat(' ', $this->style->getRightHandPadding(mb_strwidth(s::stripAnsiEscapeSequence($row)))),
                 $invertedColoursUnsetCode,
                 $borderColour,
                 str_repeat(' ', $this->style->getBorderRightWidth()),

--- a/src/Dialogue/CancellableConfirm.php
+++ b/src/Dialogue/CancellableConfirm.php
@@ -45,10 +45,10 @@ class CancellableConfirm extends Dialogue
 
         $this->terminal->moveCursorToRow($this->y);
 
-        $promptWidth = mb_strlen($this->text) + 4;
+        $promptWidth = mb_strwidth($this->text) + 4;
 
-        $buttonLength = mb_strlen($confirmText) + 6;
-        $buttonLength += mb_strlen($cancelText) + 7;
+        $buttonLength = mb_strwidth($confirmText) + 6;
+        $buttonLength += mb_strwidth($cancelText) + 7;
 
         $confirmButton = sprintf(
             '%s%s < %s > %s%s',
@@ -78,7 +78,7 @@ class CancellableConfirm extends Dialogue
                 $this->text,
                 str_repeat(' ', intval(round($pad, 0, 1) + $this->style->getPaddingLeftRight()))
             );
-            $promptWidth = mb_strlen($this->text) + 4;
+            $promptWidth = mb_strwidth($this->text) + 4;
         }
 
         $leftFill = (int) (($promptWidth / 2) - ($buttonLength / 2));

--- a/src/Dialogue/Confirm.php
+++ b/src/Dialogue/Confirm.php
@@ -21,7 +21,7 @@ class Confirm extends Dialogue
 
         $this->terminal->moveCursorToRow($this->y);
 
-        $promptWidth = mb_strlen($this->text) + 4;
+        $promptWidth = mb_strwidth($this->text) + 4;
 
         $this->emptyRow();
 
@@ -37,7 +37,7 @@ class Confirm extends Dialogue
         $this->emptyRow();
 
         $confirmText = sprintf(' < %s > ', $confirmText);
-        $leftFill    = (int) (($promptWidth / 2) - (mb_strlen($confirmText) / 2));
+        $leftFill    = (int) (($promptWidth / 2) - (mb_strwidth($confirmText) / 2));
 
         $this->write(sprintf(
             "%s%s%s%s%s%s%s\n",
@@ -46,7 +46,7 @@ class Confirm extends Dialogue
             $this->style->getInvertedColoursSetCode(),
             $confirmText,
             $this->style->getInvertedColoursUnsetCode(),
-            str_repeat(' ', (int) ceil($promptWidth - $leftFill - mb_strlen($confirmText))),
+            str_repeat(' ', (int) ceil($promptWidth - $leftFill - mb_strwidth($confirmText))),
             $this->style->getColoursResetCode()
         ));
 
@@ -54,7 +54,7 @@ class Confirm extends Dialogue
             "%s%s%s%s%s\n",
             $this->style->getColoursSetCode(),
             str_repeat(' ', $this->style->getPaddingLeftRight()),
-            str_repeat(' ', mb_strlen($this->text)),
+            str_repeat(' ', mb_strwidth($this->text)),
             str_repeat(' ', $this->style->getPaddingLeftRight()),
             $this->style->getColoursResetCode()
         ));

--- a/src/Dialogue/Dialogue.php
+++ b/src/Dialogue/Dialogue.php
@@ -83,7 +83,7 @@ abstract class Dialogue
 
         //x
         $parentStyle = $this->parentMenu->getStyle();
-        $dialogueHalfLength = (int) ((mb_strlen($this->text) + ($this->style->getPaddingLeftRight() * 2)) / 2);
+        $dialogueHalfLength = (int) ((mb_strwidth($this->text) + ($this->style->getPaddingLeftRight() * 2)) / 2);
         $widthHalfLength = (int) ceil($parentStyle->getWidth() / 2 + $parentStyle->getMargin());
         $this->x = $widthHalfLength - $dialogueHalfLength;
     }
@@ -98,7 +98,7 @@ abstract class Dialogue
                 "%s%s%s%s%s\n",
                 $this->style->getColoursSetCode(),
                 str_repeat(' ', $this->style->getPaddingLeftRight()),
-                str_repeat(' ', mb_strlen($this->text)),
+                str_repeat(' ', mb_strwidth($this->text)),
                 str_repeat(' ', $this->style->getPaddingLeftRight()),
                 $this->style->getColoursResetCode()
             )

--- a/src/Input/InputIO.php
+++ b/src/Input/InputIO.php
@@ -107,7 +107,7 @@ class InputIO
         return max(
             array_map(
                 function (string $line) {
-                    return mb_strlen($line);
+                    return mb_strwidth($line);
                 },
                 $lines
             )
@@ -171,7 +171,7 @@ class InputIO
             ]
         );
 
-        $textLength = mb_strlen(StringUtil::stripAnsiEscapeSequence($text));
+        $textLength = mb_strwidth(StringUtil::stripAnsiEscapeSequence($text));
         $leftFill   = (int) (($width / 2) - ($textLength / 2));
         $rightFill  = (int) ceil($width - $leftFill - $textLength);
 

--- a/src/Input/Password.php
+++ b/src/Input/Password.php
@@ -111,12 +111,12 @@ class Password implements Input
             return $validator($input);
         }
 
-        return mb_strlen($input) >= $this->passwordLength;
+        return mb_strwidth($input) >= $this->passwordLength;
     }
 
     public function filter(string $value) : string
     {
-        return str_repeat('*', mb_strlen($value));
+        return str_repeat('*', mb_strwidth($value));
     }
 
     public function getStyle() : MenuStyle

--- a/src/MenuItem/AsciiArtItem.php
+++ b/src/MenuItem/AsciiArtItem.php
@@ -127,7 +127,7 @@ class AsciiArtItem implements MenuItemInterface
      */
     private function calculateArtLength() : void
     {
-        $this->artLength = (int) max(array_map('mb_strlen', explode("\n", $this->text)));
+        $this->artLength = (int) max(array_map('mb_strwidth', explode("\n", $this->text)));
     }
 
     /**

--- a/src/MenuItem/SelectableItemRenderer.php
+++ b/src/MenuItem/SelectableItemRenderer.php
@@ -36,7 +36,7 @@ class SelectableItemRenderer
             s::wordwrap(
                 "{$marker}{$text}",
                 $availableWidth,
-                sprintf("\n%s", $this->emptyString(mb_strlen($marker)))
+                sprintf("\n%s", $this->emptyString(mb_strwidth($marker)))
             )
         );
     }
@@ -59,7 +59,7 @@ class SelectableItemRenderer
     public function getAvailableTextWidth(MenuStyle $menuStyle, ItemStyle $itemStyle) : int
     {
         return $itemStyle->getDisplaysExtra()
-            ? $menuStyle->getContentWidth() - (mb_strlen($itemStyle->getItemExtra()) + 2)
+            ? $menuStyle->getContentWidth() - (mb_strwidth($itemStyle->getItemExtra()) + 2)
             : $menuStyle->getContentWidth();
     }
 }

--- a/src/MenuItem/SplitItem.php
+++ b/src/MenuItem/SplitItem.php
@@ -154,7 +154,7 @@ class SplitItem implements MenuItemInterface, PropagatesStyles
                     $itemExtraVal = $item->getStyle()->getItemExtra();
                     $itemExtra = $item->showsItemExtra()
                         ? sprintf('  %s', $itemExtraVal)
-                        : sprintf('  %s', str_repeat(' ', mb_strlen($itemExtraVal)));
+                        : sprintf('  %s', str_repeat(' ', mb_strwidth($itemExtraVal)));
                 }
 
                 return $this->buildCell(
@@ -163,7 +163,7 @@ class SplitItem implements MenuItemInterface, PropagatesStyles
                         StringUtil::wordwrap(
                             sprintf('%s%s', $marker, $item->getText()),
                             $length,
-                            sprintf("\n%s", str_repeat(' ', mb_strlen($marker)))
+                            sprintf("\n%s", str_repeat(' ', mb_strwidth($marker)))
                         )
                     ),
                     $length,
@@ -226,8 +226,8 @@ class SplitItem implements MenuItemInterface, PropagatesStyles
                 '%s%s%s%s%s%s',
                 $invertedColoursSetCode,
                 $row,
-                str_repeat(' ', $length - mb_strlen($row)),
-                $index === 0 ? $itemExtra : str_repeat(' ', mb_strlen($itemExtra)),
+                str_repeat(' ', $length - mb_strwidth($row)),
+                $index === 0 ? $itemExtra : str_repeat(' ', mb_strwidth($itemExtra)),
                 $invertedColoursUnsetCode,
                 str_repeat(' ', $this->gutter)
             );
@@ -339,7 +339,7 @@ class SplitItem implements MenuItemInterface, PropagatesStyles
     {
         return max(array_map(
             function (MenuItemInterface $item) {
-                return mb_strlen($item->getStyle()->getItemExtra());
+                return mb_strwidth($item->getStyle()->getItemExtra());
             },
             array_filter($this->items, function (MenuItemInterface $item) {
                 return $item->getStyle()->getDisplaysExtra();

--- a/src/Util/StringUtil.php
+++ b/src/Util/StringUtil.php
@@ -18,7 +18,7 @@ class StringUtil
             $break,
             array_map(function (string $line) use ($width, $break) {
                 $line = rtrim($line);
-                if (mb_strlen($line) <= $width) {
+                if (mb_strwidth($line) <= $width) {
                     return $line;
                 }
                 
@@ -26,7 +26,7 @@ class StringUtil
                 $line   = '';
                 $actual = '';
                 foreach ($words as $word) {
-                    if (mb_strlen($actual . $word) <= $width) {
+                    if (mb_strwidth($actual . $word) <= $width) {
                         $actual .= $word . ' ';
                     } else {
                         if ($actual !== '') {
@@ -47,6 +47,6 @@ class StringUtil
 
     public static function length(string $str, bool $ignoreAnsiEscapeSequence = true) : int
     {
-        return mb_strlen($ignoreAnsiEscapeSequence ? self::stripAnsiEscapeSequence($str) : $str);
+        return mb_strwidth($ignoreAnsiEscapeSequence ? self::stripAnsiEscapeSequence($str) : $str);
     }
 }


### PR DESCRIPTION
Since full-width characters will break the UI, we should detect the visual width of the string using `mb_strwidth` instead of `mb_strlen`.

- Use `mb_strlen` when you are detecting the string length for word counting.
- Use `mb_strwidth` when you are detecting the string width on the screen.

I replace all the `mb_strlen` into `mb_strwidth` because none of them are used to detecting the string length for word counting. They all are used to get the string width on the screen.

You may now use this commit to make CJK characters perfectly fit in the dialog. 😃

正體中文：由於 `mb_strlen` 是用來計算字串中的字元數量而非寬度，因此需將所有計算字串寬度的函數中的實作都改成使用 `mb_strwidth` 才不會造成跑版。現有的 `mb_strlen` 經人工檢視後發現，用途皆為計算寬度而非字數，因此我將該些實作全部從 `mb_strlen` 改成 `mb_strwidth`，如此 CJK 字元以及其他全型字元將不會造成跑版。