### PR TITLE
Accept any callable as argument for addSubMenu and addSplitItem in CliMenuBuilder

### DIFF
--- a/src/Builder/CliMenuBuilder.php
+++ b/src/Builder/CliMenuBuilder.php
@@ -315,7 +315,7 @@ class CliMenuBuilder
         }
     }
 
-    public function addSplitItem(\Closure $callback) : self
+    public function addSplitItem(callable $callback) : self
     {
         $builder = new SplitItemBuilder($this->menu);
 

--- a/src/Builder/CliMenuBuilder.php
+++ b/src/Builder/CliMenuBuilder.php
@@ -205,7 +205,7 @@ class CliMenuBuilder
         return $this;
     }
 
-    public function addSubMenu(string $text, \Closure $callback) : self
+    public function addSubMenu(string $text, callable $callback) : self
     {
         $builder = self::newSubMenu($this->terminal);
 


### PR DESCRIPTION
While working on a personal project I was structuring all actions to be callable objects (using the `__invoke` method) and stumbled upon the `addSubMenu` method not accepting them as a callback. This PR modifies the argument type so it accepts any callable as defined [here](https://www.php.net/manual/en/language.types.callable.php)