### PR TITLE
Add option to change the newlines before and after the menu is drawn

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,19 @@ $menu = (new CliMenuBuilder)
     ->build();
 ```
 
+You can also change the number of newlines before and after the menu acting sort like a vertical margin:
+
+```php
+<?php
+
+use PhpSchool\CliMenu\Builder\CliMenuBuilder;
+
+$menu = (new CliMenuBuilder)
+    ->setWidth(200)
+    ->setFrameNewlines(5, 2) // top, bottom
+    ->build();
+```
+
 #### Borders
 
 Borders can be customised just like CSS borders. We can add any amount of border to either side, left, right top or 

--- a/src/Builder/CliMenuBuilder.php
+++ b/src/Builder/CliMenuBuilder.php
@@ -494,6 +494,14 @@ class CliMenuBuilder
         return $this;
     }
 
+    public function setFrameNewlines(int $top, int $bottom) : self
+    {
+        $this->style->setFrameTopNewlines($top);
+        $this->style->setFrameBottomNewlines($bottom);
+
+        return $this;
+    }
+
     public function getStyle() : MenuStyle
     {
         return $this->style;

--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -492,8 +492,11 @@ class CliMenu
     protected function draw() : void
     {
         $frame = new Frame;
-
-        $frame->newLine(2);
+        
+        $lines = $this->style->getFrameTopNewlines();
+        if ($lines>0) {
+            $frame->newLine($lines);
+        }
 
         if ($this->style->getBorderTopWidth() > 0) {
             $frame->addRows($this->style->getBorderTopRows());
@@ -521,7 +524,10 @@ class CliMenu
             $frame->addRows($this->style->getBorderBottomRows());
         }
 
-        $frame->newLine(2);
+        $lines = $this->style->getFrameBottomNewlines();
+        if ($lines>0) {
+            $frame->newLine($lines);
+        }
 
         $this->terminal->moveCursorToTop();
         foreach ($frame->getRows() as $row) {

--- a/src/MenuStyle.php
+++ b/src/MenuStyle.php
@@ -160,6 +160,16 @@ class MenuStyle
     private $debugMode = false;
 
     /**
+     * @var int
+     */
+    protected $frameTopNewlines = 2;
+
+    /**
+     * @var int
+     */
+    protected $frameBottomNewlines = 2;
+
+    /**
      * Default Values
      *
      * @var array
@@ -816,6 +826,32 @@ class MenuStyle
         }
 
         return sprintf("\033[%sm", $borderColourCode);
+    }
+
+    public function getFrameTopNewlines() : int
+    {
+        return $this->frameTopNewlines;
+    }
+
+    public function getFrameBottomNewlines() : int
+    {
+        return $this->frameBottomNewlines;
+    }
+
+    public function setFrameTopNewlines(int $lines) : self
+    {
+        Assertion::greaterOrEqualThan($lines, 0);
+        $this->frameTopNewlines = $lines;
+
+        return $this;
+    }
+
+    public function setFrameBottomNewlines(int $lines) : self
+    {
+        Assertion::greaterOrEqualThan($lines, 0);
+        $this->frameBottomNewlines = $lines;
+
+        return $this;
     }
 
 


### PR DESCRIPTION
This feature is useful because it allows you to either reduce or set to zero the vertical margins in cases of a small terminal window (my case for which I made this feature) or a very large menu and you have to use every inch to fit it into the terminal,
or you can increment it to move or center the menu vertically.