### PR TITLE
Fix 8.4 deprecations

### DIFF
--- a/src/Builder/CliMenuBuilder.php
+++ b/src/Builder/CliMenuBuilder.php
@@ -93,7 +93,7 @@ class CliMenuBuilder
      */
     private $subMenu = false;
 
-    public function __construct(Terminal $terminal = null)
+    public function __construct(?Terminal $terminal = null)
     {
         $this->terminal = $terminal ?? TerminalFactory::fromSystem();
         $this->style    = new MenuStyle($this->terminal);
@@ -249,7 +249,7 @@ class CliMenuBuilder
         return $this;
     }
 
-    public function enableAutoShortcuts(string $regex = null) : self
+    public function enableAutoShortcuts(?string $regex = null) : self
     {
         $this->autoShortcuts = true;
 
@@ -373,14 +373,14 @@ class CliMenuBuilder
         return $this;
     }
 
-    public function setBackgroundColour(string $colour, string $fallback = null) : self
+    public function setBackgroundColour(string $colour, ?string $fallback = null) : self
     {
         $this->style->setBg($colour, $fallback);
 
         return $this;
     }
 
-    public function setForegroundColour(string $colour, string $fallback = null) : self
+    public function setForegroundColour(string $colour, ?string $fallback = null) : self
     {
         $this->style->setFg($colour, $fallback);
 
@@ -394,7 +394,7 @@ class CliMenuBuilder
         return $this;
     }
 
-    public function setPadding(int $topBottom, int $leftRight = null) : self
+    public function setPadding(int $topBottom, ?int $leftRight = null) : self
     {
         $this->style->setPadding($topBottom, $leftRight);
 
@@ -452,7 +452,7 @@ class CliMenuBuilder
      * @param int|string|null $bottom
      * @param int|string|null $left
      */
-    public function setBorder(int $top, $right = null, $bottom = null, $left = null, string $colour = null) : self
+    public function setBorder(int $top, $right = null, $bottom = null, $left = null, ?string $colour = null) : self
     {
         $this->style->setBorder($top, $right, $bottom, $left, $colour);
 
@@ -487,7 +487,7 @@ class CliMenuBuilder
         return $this;
     }
 
-    public function setBorderColour(string $colour, string $fallback = null) : self
+    public function setBorderColour(string $colour, ?string $fallback = null) : self
     {
         $this->style->setBorderColour($colour, $fallback);
 

--- a/src/Builder/SplitItemBuilder.php
+++ b/src/Builder/SplitItemBuilder.php
@@ -144,7 +144,7 @@ class SplitItemBuilder
         return $this;
     }
 
-    public function enableAutoShortcuts(string $regex = null) : self
+    public function enableAutoShortcuts(?string $regex = null) : self
     {
         $this->autoShortcuts = true;
 

--- a/src/CliMenu.php
+++ b/src/CliMenu.php
@@ -99,8 +99,8 @@ class CliMenu
     public function __construct(
         ?string $title,
         array $items,
-        Terminal $terminal = null,
-        MenuStyle $style = null
+        ?Terminal $terminal = null,
+        ?MenuStyle $style = null
     ) {
         $this->title           = $title;
         $this->items           = $items;
@@ -696,7 +696,7 @@ class CliMenu
         return $this->currentFrame;
     }
 
-    public function flash(string $text, MenuStyle $style = null) : Flash
+    public function flash(string $text, ?MenuStyle $style = null) : Flash
     {
         $this->guardSingleLine($text);
 
@@ -707,7 +707,7 @@ class CliMenu
         return new Flash($this, $style, $this->terminal, $text);
     }
 
-    public function confirm(string $text, MenuStyle $style = null) : Confirm
+    public function confirm(string $text, ?MenuStyle $style = null) : Confirm
     {
         $this->guardSingleLine($text);
 
@@ -718,7 +718,7 @@ class CliMenu
         return new Confirm($this, $style, $this->terminal, $text);
     }
 
-    public function cancellableConfirm(string $text, MenuStyle $style = null) : CancellableConfirm
+    public function cancellableConfirm(string $text, ?MenuStyle $style = null) : CancellableConfirm
     {
         $this->guardSingleLine($text);
 
@@ -729,7 +729,7 @@ class CliMenu
         return new CancellableConfirm($this, $style, $this->terminal, $text);
     }
 
-    public function askNumber(MenuStyle $style = null) : Number
+    public function askNumber(?MenuStyle $style = null) : Number
     {
         $this->assertOpen();
 
@@ -740,7 +740,7 @@ class CliMenu
         return new Number(new InputIO($this, $this->terminal), $style);
     }
 
-    public function askText(MenuStyle $style = null) : Text
+    public function askText(?MenuStyle $style = null) : Text
     {
         $this->assertOpen();
 
@@ -751,7 +751,7 @@ class CliMenu
         return new Text(new InputIO($this, $this->terminal), $style);
     }
 
-    public function askPassword(MenuStyle $style = null) : Password
+    public function askPassword(?MenuStyle $style = null) : Password
     {
         $this->assertOpen();
 

--- a/src/Dialogue/Dialogue.php
+++ b/src/Dialogue/Dialogue.php
@@ -108,7 +108,7 @@ abstract class Dialogue
     /**
      * Write some text at a particular column
      */
-    protected function write(string $text, int $column = null) : void
+    protected function write(string $text, ?int $column = null) : void
     {
         $this->terminal->moveCursorToColumn($column ?: $this->x);
         $this->terminal->write($text);

--- a/src/MenuStyle.php
+++ b/src/MenuStyle.php
@@ -227,7 +227,7 @@ class MenuStyle
     /**
      * Initialise style
      */
-    public function __construct(Terminal $terminal = null)
+    public function __construct(?Terminal $terminal = null)
     {
         $this->terminal = $terminal ?: TerminalFactory::fromSystem();
 
@@ -401,7 +401,7 @@ class MenuStyle
         return $this->fg;
     }
 
-    public function setFg(string $fg, string $fallback = null) : self
+    public function setFg(string $fg, ?string $fallback = null) : self
     {
         $this->fg = ColourUtil::validateColour(
             $this->terminal,
@@ -418,7 +418,7 @@ class MenuStyle
         return $this->bg;
     }
 
-    public function setBg(string $bg, string $fallback = null) : self
+    public function setBg(string $bg, ?string $fallback = null) : self
     {
         $this->bg = ColourUtil::validateColour(
             $this->terminal,
@@ -522,7 +522,7 @@ class MenuStyle
         return $this->paddingTopBottomRows;
     }
 
-    public function setPadding(int $topBottom, int $leftRight = null) : self
+    public function setPadding(int $topBottom, ?int $leftRight = null) : self
     {
         if ($leftRight === null) {
             $leftRight = $topBottom;
@@ -700,7 +700,7 @@ class MenuStyle
         $rightWidth = null,
         $bottomWidth = null,
         $leftWidth = null,
-        string $colour = null
+        ?string $colour = null
     ) : self {
         if (!is_int($rightWidth)) {
             $colour = $rightWidth;
@@ -768,7 +768,7 @@ class MenuStyle
         return $this;
     }
 
-    public function setBorderColour(string $colour, string $fallback = null) : self
+    public function setBorderColour(string $colour, ?string $fallback = null) : self
     {
         $this->borderColour = ColourUtil::validateColour(
             $this->terminal,

--- a/src/Util/ColourUtil.php
+++ b/src/Util/ColourUtil.php
@@ -307,7 +307,7 @@ class ColourUtil
      * Check if $colour exists
      * If it's a 256-colours code and $terminal doesn't support it, returns a fallback value
      */
-    public static function validateColour(Terminal $terminal, string $colour, string $fallback = null) : string
+    public static function validateColour(Terminal $terminal, string $colour, ?string $fallback = null) : string
     {
         if (!is_numeric($colour)) {
             return self::validateColourName($colour);


### PR DESCRIPTION
Fixes deprecation errors that you receive when using php 8.4

Example:
`ERROR: PhpSchool\CliMenu\MenuStyle::setBorder(): Implicitly marking parameter $colour as nullable is deprecated, the explicit nullable type must be used instead`